### PR TITLE
docs: add complete Docker Hub images list to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,10 +616,15 @@ Use the admin UI or API to:
 
 ## Docker Images
 
+All images are available on [Docker Hub](https://hub.docker.com/orgs/dyetech/repositories).
+
 | Image | Description |
 |-------|-------------|
 | [`dyetech/gatekey-server`](https://hub.docker.com/r/dyetech/gatekey-server) | Control plane (API + embedded CA) |
 | [`dyetech/gatekey-web`](https://hub.docker.com/r/dyetech/gatekey-web) | Web UI (nginx + React) |
+| [`dyetech/gatekey-gateway`](https://hub.docker.com/r/dyetech/gatekey-gateway) | OpenVPN gateway agent |
+| [`dyetech/gatekey-hub`](https://hub.docker.com/r/dyetech/gatekey-hub) | OpenVPN mesh hub |
+| [`dyetech/gatekey-mesh-gateway`](https://hub.docker.com/r/dyetech/gatekey-mesh-gateway) | OpenVPN mesh spoke |
 | [`dyetech/gatekey-wireguard-gateway`](https://hub.docker.com/r/dyetech/gatekey-wireguard-gateway) | WireGuard gateway agent |
 | [`dyetech/gatekey-wireguard-hub`](https://hub.docker.com/r/dyetech/gatekey-wireguard-hub) | WireGuard mesh hub |
 | [`dyetech/gatekey-wireguard-mesh-gateway`](https://hub.docker.com/r/dyetech/gatekey-wireguard-mesh-gateway) | WireGuard mesh spoke |


### PR DESCRIPTION
## Summary

- Add link to Docker Hub organization page
- Add missing OpenVPN images that were not listed
- Document all 8 available Docker images

## Changes

The Docker Images section now includes:

| Image | Description |
|-------|-------------|
| `dyetech/gatekey-server` | Control plane |
| `dyetech/gatekey-web` | Web UI |
| `dyetech/gatekey-gateway` | OpenVPN gateway (added) |
| `dyetech/gatekey-hub` | OpenVPN mesh hub (added) |
| `dyetech/gatekey-mesh-gateway` | OpenVPN mesh spoke (added) |
| `dyetech/gatekey-wireguard-gateway` | WireGuard gateway |
| `dyetech/gatekey-wireguard-hub` | WireGuard mesh hub |
| `dyetech/gatekey-wireguard-mesh-gateway` | WireGuard mesh spoke |

Docker Hub: https://hub.docker.com/orgs/dyetech/repositories