### PR TITLE
feat(homebrew): add formulas for WireGuard and mesh components

### DIFF
--- a/build/package/homebrew/gatekey-hub.rb
+++ b/build/package/homebrew/gatekey-hub.rb
@@ -1,0 +1,66 @@
+# typed: false
+# frozen_string_literal: true
+
+# Homebrew formula for GateKey Mesh Hub
+# Install with: brew install dye-tech/tap/gatekey-hub
+class GatekeyHub < Formula
+  desc "Zero Trust OpenVPN mesh hub for GateKey"
+  homepage "https://github.com/dye-tech/GateKey"
+  version "VERSION_PLACEHOLDER"
+  license "Apache-2.0"
+
+  on_macos do
+    on_intel do
+      url "https://github.com/dye-tech/GateKey/releases/download/vVERSION_PLACEHOLDER/gatekey-hub-VERSION_PLACEHOLDER-darwin-amd64.tar.gz"
+      sha256 "SHA256_DARWIN_AMD64_PLACEHOLDER"
+    end
+
+    on_arm do
+      url "https://github.com/dye-tech/GateKey/releases/download/vVERSION_PLACEHOLDER/gatekey-hub-VERSION_PLACEHOLDER-darwin-arm64.tar.gz"
+      sha256 "SHA256_DARWIN_ARM64_PLACEHOLDER"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/dye-tech/GateKey/releases/download/vVERSION_PLACEHOLDER/gatekey-hub-VERSION_PLACEHOLDER-linux-amd64.tar.gz"
+      sha256 "SHA256_LINUX_AMD64_PLACEHOLDER"
+    end
+
+    on_arm do
+      url "https://github.com/dye-tech/GateKey/releases/download/vVERSION_PLACEHOLDER/gatekey-hub-VERSION_PLACEHOLDER-linux-arm64.tar.gz"
+      sha256 "SHA256_LINUX_ARM64_PLACEHOLDER"
+    end
+  end
+
+  depends_on "openvpn" => :recommended
+
+  def install
+    bin.install "gatekey-hub"
+  end
+
+  def caveats
+    <<~EOS
+      GateKey Mesh Hub has been installed.
+
+      The mesh hub provides hub-and-spoke VPN topology for site-to-site connectivity.
+
+      Requirements:
+        1. OpenVPN server installation
+        2. Registration with a GateKey control plane
+        3. Configuration file at /etc/gatekey/hub.yaml
+
+      Features:
+        - Zero-trust access control per network
+        - Full tunnel mode support
+        - Push DNS to mesh clients
+
+      For production deployments, consider using Docker or Kubernetes.
+      See: https://github.com/dye-tech/GateKey/blob/main/docs/mesh-networking.md
+    EOS
+  end
+
+  test do
+    assert_match "gatekey-hub", shell_output("#{bin}/gatekey-hub version 2>&1", 0)
+  end
+end

--- a/build/package/homebrew/gatekey-mesh-gateway.rb
+++ b/build/package/homebrew/gatekey-mesh-gateway.rb
@@ -1,0 +1,66 @@
+# typed: false
+# frozen_string_literal: true
+
+# Homebrew formula for GateKey Mesh Gateway (Spoke)
+# Install with: brew install dye-tech/tap/gatekey-mesh-gateway
+class GatekeyMeshGateway < Formula
+  desc "Zero Trust OpenVPN mesh spoke for GateKey"
+  homepage "https://github.com/dye-tech/GateKey"
+  version "VERSION_PLACEHOLDER"
+  license "Apache-2.0"
+
+  on_macos do
+    on_intel do
+      url "https://github.com/dye-tech/GateKey/releases/download/vVERSION_PLACEHOLDER/gatekey-mesh-gateway-VERSION_PLACEHOLDER-darwin-amd64.tar.gz"
+      sha256 "SHA256_DARWIN_AMD64_PLACEHOLDER"
+    end
+
+    on_arm do
+      url "https://github.com/dye-tech/GateKey/releases/download/vVERSION_PLACEHOLDER/gatekey-mesh-gateway-VERSION_PLACEHOLDER-darwin-arm64.tar.gz"
+      sha256 "SHA256_DARWIN_ARM64_PLACEHOLDER"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/dye-tech/GateKey/releases/download/vVERSION_PLACEHOLDER/gatekey-mesh-gateway-VERSION_PLACEHOLDER-linux-amd64.tar.gz"
+      sha256 "SHA256_LINUX_AMD64_PLACEHOLDER"
+    end
+
+    on_arm do
+      url "https://github.com/dye-tech/GateKey/releases/download/vVERSION_PLACEHOLDER/gatekey-mesh-gateway-VERSION_PLACEHOLDER-linux-arm64.tar.gz"
+      sha256 "SHA256_LINUX_ARM64_PLACEHOLDER"
+    end
+  end
+
+  depends_on "openvpn" => :recommended
+
+  def install
+    bin.install "gatekey-mesh-gateway"
+  end
+
+  def caveats
+    <<~EOS
+      GateKey Mesh Gateway (Spoke) has been installed.
+
+      The mesh gateway connects to a mesh hub for site-to-site VPN connectivity.
+
+      Requirements:
+        1. OpenVPN client installation
+        2. Registration with a GateKey control plane
+        3. Configuration file at /etc/gatekey/mesh-gateway.yaml
+
+      Features:
+        - Connects remote sites to the mesh hub
+        - Zero-trust network access
+        - Automatic route propagation
+
+      For production deployments, consider using Docker or Kubernetes.
+      See: https://github.com/dye-tech/GateKey/blob/main/docs/mesh-networking.md
+    EOS
+  end
+
+  test do
+    assert_match "gatekey-mesh-gateway", shell_output("#{bin}/gatekey-mesh-gateway version 2>&1", 0)
+  end
+end

--- a/build/package/homebrew/gatekey-wireguard-gateway.rb
+++ b/build/package/homebrew/gatekey-wireguard-gateway.rb
@@ -1,0 +1,61 @@
+# typed: false
+# frozen_string_literal: true
+
+# Homebrew formula for GateKey WireGuard Gateway Agent
+# Install with: brew install dye-tech/tap/gatekey-wireguard-gateway
+class GatekeyWireguardGateway < Formula
+  desc "Zero Trust WireGuard gateway agent for GateKey"
+  homepage "https://github.com/dye-tech/GateKey"
+  version "VERSION_PLACEHOLDER"
+  license "Apache-2.0"
+
+  on_macos do
+    on_intel do
+      url "https://github.com/dye-tech/GateKey/releases/download/vVERSION_PLACEHOLDER/gatekey-wireguard-gateway-VERSION_PLACEHOLDER-darwin-amd64.tar.gz"
+      sha256 "SHA256_DARWIN_AMD64_PLACEHOLDER"
+    end
+
+    on_arm do
+      url "https://github.com/dye-tech/GateKey/releases/download/vVERSION_PLACEHOLDER/gatekey-wireguard-gateway-VERSION_PLACEHOLDER-darwin-arm64.tar.gz"
+      sha256 "SHA256_DARWIN_ARM64_PLACEHOLDER"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/dye-tech/GateKey/releases/download/vVERSION_PLACEHOLDER/gatekey-wireguard-gateway-VERSION_PLACEHOLDER-linux-amd64.tar.gz"
+      sha256 "SHA256_LINUX_AMD64_PLACEHOLDER"
+    end
+
+    on_arm do
+      url "https://github.com/dye-tech/GateKey/releases/download/vVERSION_PLACEHOLDER/gatekey-wireguard-gateway-VERSION_PLACEHOLDER-linux-arm64.tar.gz"
+      sha256 "SHA256_LINUX_ARM64_PLACEHOLDER"
+    end
+  end
+
+  depends_on "wireguard-tools" => :recommended
+
+  def install
+    bin.install "gatekey-wireguard-gateway"
+  end
+
+  def caveats
+    <<~EOS
+      GateKey WireGuard Gateway Agent has been installed.
+
+      The gateway agent runs alongside WireGuard and requires:
+        1. WireGuard kernel module or wireguard-go
+        2. Registration with a GateKey control plane
+        3. Configuration file at /etc/gatekey/wireguard-gateway.yaml
+
+      For Linux servers, the recommended installation is via the install script:
+        curl -sSL https://your-gatekey-server/scripts/install-wireguard-gateway.sh | GATEWAY_TOKEN=<token> bash
+
+      See: https://github.com/dye-tech/GateKey/blob/main/docs/wireguard-gateway-setup.md
+    EOS
+  end
+
+  test do
+    assert_match "gatekey-wireguard-gateway", shell_output("#{bin}/gatekey-wireguard-gateway version 2>&1", 0)
+  end
+end

--- a/build/package/homebrew/gatekey-wireguard-hub.rb
+++ b/build/package/homebrew/gatekey-wireguard-hub.rb
@@ -1,0 +1,67 @@
+# typed: false
+# frozen_string_literal: true
+
+# Homebrew formula for GateKey WireGuard Mesh Hub
+# Install with: brew install dye-tech/tap/gatekey-wireguard-hub
+class GatekeyWireguardHub < Formula
+  desc "Zero Trust WireGuard mesh hub for GateKey"
+  homepage "https://github.com/dye-tech/GateKey"
+  version "VERSION_PLACEHOLDER"
+  license "Apache-2.0"
+
+  on_macos do
+    on_intel do
+      url "https://github.com/dye-tech/GateKey/releases/download/vVERSION_PLACEHOLDER/gatekey-wireguard-hub-VERSION_PLACEHOLDER-darwin-amd64.tar.gz"
+      sha256 "SHA256_DARWIN_AMD64_PLACEHOLDER"
+    end
+
+    on_arm do
+      url "https://github.com/dye-tech/GateKey/releases/download/vVERSION_PLACEHOLDER/gatekey-wireguard-hub-VERSION_PLACEHOLDER-darwin-arm64.tar.gz"
+      sha256 "SHA256_DARWIN_ARM64_PLACEHOLDER"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/dye-tech/GateKey/releases/download/vVERSION_PLACEHOLDER/gatekey-wireguard-hub-VERSION_PLACEHOLDER-linux-amd64.tar.gz"
+      sha256 "SHA256_LINUX_AMD64_PLACEHOLDER"
+    end
+
+    on_arm do
+      url "https://github.com/dye-tech/GateKey/releases/download/vVERSION_PLACEHOLDER/gatekey-wireguard-hub-VERSION_PLACEHOLDER-linux-arm64.tar.gz"
+      sha256 "SHA256_LINUX_ARM64_PLACEHOLDER"
+    end
+  end
+
+  depends_on "wireguard-tools" => :recommended
+
+  def install
+    bin.install "gatekey-wireguard-hub"
+  end
+
+  def caveats
+    <<~EOS
+      GateKey WireGuard Mesh Hub has been installed.
+
+      The WireGuard mesh hub provides hub-and-spoke VPN topology using WireGuard protocol.
+
+      Requirements:
+        1. WireGuard kernel module or wireguard-go
+        2. Registration with a GateKey control plane
+        3. Configuration file at /etc/gatekey/wireguard-hub.yaml
+
+      Features:
+        - Zero-trust access control per network
+        - Full tunnel mode support
+        - Push DNS to mesh clients
+        - Modern WireGuard protocol with better performance
+
+      For production deployments, consider using Docker or Kubernetes.
+      See: https://github.com/dye-tech/GateKey/blob/main/docs/wireguard-mesh-networking.md
+    EOS
+  end
+
+  test do
+    assert_match "gatekey-wireguard-hub", shell_output("#{bin}/gatekey-wireguard-hub version 2>&1", 0)
+  end
+end

--- a/build/package/homebrew/gatekey-wireguard-mesh-gateway.rb
+++ b/build/package/homebrew/gatekey-wireguard-mesh-gateway.rb
@@ -1,0 +1,67 @@
+# typed: false
+# frozen_string_literal: true
+
+# Homebrew formula for GateKey WireGuard Mesh Gateway (Spoke)
+# Install with: brew install dye-tech/tap/gatekey-wireguard-mesh-gateway
+class GatekeyWireguardMeshGateway < Formula
+  desc "Zero Trust WireGuard mesh spoke for GateKey"
+  homepage "https://github.com/dye-tech/GateKey"
+  version "VERSION_PLACEHOLDER"
+  license "Apache-2.0"
+
+  on_macos do
+    on_intel do
+      url "https://github.com/dye-tech/GateKey/releases/download/vVERSION_PLACEHOLDER/gatekey-wireguard-mesh-gateway-VERSION_PLACEHOLDER-darwin-amd64.tar.gz"
+      sha256 "SHA256_DARWIN_AMD64_PLACEHOLDER"
+    end
+
+    on_arm do
+      url "https://github.com/dye-tech/GateKey/releases/download/vVERSION_PLACEHOLDER/gatekey-wireguard-mesh-gateway-VERSION_PLACEHOLDER-darwin-arm64.tar.gz"
+      sha256 "SHA256_DARWIN_ARM64_PLACEHOLDER"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/dye-tech/GateKey/releases/download/vVERSION_PLACEHOLDER/gatekey-wireguard-mesh-gateway-VERSION_PLACEHOLDER-linux-amd64.tar.gz"
+      sha256 "SHA256_LINUX_AMD64_PLACEHOLDER"
+    end
+
+    on_arm do
+      url "https://github.com/dye-tech/GateKey/releases/download/vVERSION_PLACEHOLDER/gatekey-wireguard-mesh-gateway-VERSION_PLACEHOLDER-linux-arm64.tar.gz"
+      sha256 "SHA256_LINUX_ARM64_PLACEHOLDER"
+    end
+  end
+
+  depends_on "wireguard-tools" => :recommended
+
+  def install
+    bin.install "gatekey-wireguard-mesh-gateway"
+  end
+
+  def caveats
+    <<~EOS
+      GateKey WireGuard Mesh Gateway (Spoke) has been installed.
+
+      The WireGuard mesh gateway connects to a mesh hub for site-to-site VPN connectivity.
+
+      Requirements:
+        1. WireGuard kernel module or wireguard-go
+        2. Registration with a GateKey control plane
+        3. Configuration file at /etc/gatekey/wireguard-mesh-gateway.yaml
+
+      Features:
+        - Connects remote sites to the WireGuard mesh hub
+        - Zero-trust network access
+        - Automatic route propagation
+        - Modern WireGuard protocol with better performance
+
+      For production deployments, consider using Docker or Kubernetes.
+      See: https://github.com/dye-tech/GateKey/blob/main/docs/wireguard-mesh-networking.md
+    EOS
+  end
+
+  test do
+    assert_match "gatekey-wireguard-mesh-gateway", shell_output("#{bin}/gatekey-wireguard-mesh-gateway version 2>&1", 0)
+  end
+end

--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -26,7 +26,7 @@ fi
 echo "Updating Homebrew formulas to version ${VERSION}..."
 
 # Formulas and their corresponding binary names
-FORMULAS="gatekey gatekey-admin gatekey-server gatekey-gateway gatekey-hub gatekey-mesh-gateway"
+FORMULAS="gatekey gatekey-admin gatekey-server gatekey-gateway gatekey-hub gatekey-mesh-gateway gatekey-wireguard-gateway gatekey-wireguard-hub gatekey-wireguard-mesh-gateway"
 
 for formula in $FORMULAS; do
     binary="$formula"


### PR DESCRIPTION
## Summary

- Add Homebrew formulas for the 5 binaries that were missing coverage
- Update `scripts/update-homebrew.sh` to include new formulas in release automation

### New Formulas

| Formula | Binary | Description |
|---------|--------|-------------|
| `gatekey-wireguard-gateway.rb` | `gatekey-wireguard-gateway` | WireGuard gateway agent |
| `gatekey-hub.rb` | `gatekey-hub` | OpenVPN mesh hub |
| `gatekey-mesh-gateway.rb` | `gatekey-mesh-gateway` | OpenVPN mesh spoke |
| `gatekey-wireguard-hub.rb` | `gatekey-wireguard-hub` | WireGuard mesh hub |
| `gatekey-wireguard-mesh-gateway.rb` | `gatekey-wireguard-mesh-gateway` | WireGuard mesh spoke |

All formulas follow the existing patterns with:
- Multi-platform support (macOS Intel/ARM, Linux AMD64/ARM64)
- Version/SHA256 placeholders for release automation
- Appropriate dependencies (wireguard-tools or openvpn)
- Usage caveats and test definitions

## Test plan

- [ ] Verify formulas pass `brew audit --strict` after version substitution
- [ ] Test installation on macOS (Intel and Apple Silicon)
- [ ] Test installation on Linux
- [ ] Verify `update-homebrew.sh` correctly processes all 9 formulas