### PR TITLE
docs: update Go and PostgreSQL version references

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,7 +29,7 @@ What actually happened.
 - **GateKey Version**: [e.g., 1.0.0]
 - **Component**: [server/gateway/client/web]
 - **OS**: [e.g., Ubuntu 22.04, macOS 14]
-- **Go Version**: [e.g., 1.23]
+- **Go Version**: [e.g., 1.25]
 - **Browser** (if web): [e.g., Chrome 120]
 
 ## Logs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,9 +43,9 @@ Feature suggestions are welcome! Please include:
 
 ### Prerequisites
 
-- Go 1.23+
+- Go 1.25+
 - Node.js 20+
-- PostgreSQL 15+
+- PostgreSQL 16+
 - Docker (optional, for testing)
 
 ### Getting Started

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ The GateKey server is the control plane that handles authentication, certificate
 
 ### Prerequisites
 
-- PostgreSQL 14+
+- PostgreSQL 16+
 - Go 1.25+ (if building from source)
 
 ### Option 1: Kubernetes (Recommended)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -194,8 +194,8 @@ kubectl rollout restart deployment -n gatekey gatekey-server gatekey-web
 
 ## Prerequisites
 
-- Go 1.23+
-- PostgreSQL 14+
+- Go 1.25+
+- PostgreSQL 16+
 - OpenVPN 2.5+
 - Node.js 20+ (for building frontend)
 - Linux server with nftables support
@@ -464,7 +464,7 @@ version: '3.8'
 
 services:
   postgres:
-    image: postgres:14
+    image: postgres:16
     environment:
       POSTGRES_DB: gatekey
       POSTGRES_USER: gatekey

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,9 +6,9 @@ This document covers development practices, linting configuration, and code styl
 
 ### Prerequisites
 
-- Go 1.23+
+- Go 1.25+
 - Node.js 20+
-- PostgreSQL 15+
+- PostgreSQL 16+
 - Docker (optional, for testing)
 - golangci-lint (for linting)
 


### PR DESCRIPTION
## Summary

Update outdated version references across documentation to match current requirements.

### Version Updates

| Dependency | Old Version | New Version |
|------------|-------------|-------------|
| Go | 1.23+ | 1.25+ |
| PostgreSQL | 14+ / 15+ | 16+ |

### Files Updated

| File | Changes |
|------|---------|
| `docs/development.md` | Go 1.23+ → 1.25+, PostgreSQL 15+ → 16+ |
| `docs/deployment.md` | Go 1.23+ → 1.25+, PostgreSQL 14+ → 16+, Docker image postgres:14 → postgres:16 |
| `CONTRIBUTING.md` | Go 1.23+ → 1.25+, PostgreSQL 15+ → 16+ |
| `README.md` | PostgreSQL 14+ → 16+ |
| `.github/ISSUE_TEMPLATE/bug_report.md` | Example Go version 1.23 → 1.25 |

### Not Changed

- `docs/fips-compliance.md` - Contains example output showing older system reports
- `docs/architecture.md` - Already correct (Go 1.25+)
- `database/README.md` - Already correct (PostgreSQL 16+)
- `go.mod` - Already correct (Go 1.25.0)
- `.github/workflows/ci.yml` - Already correct (postgres:16)

## Test plan

- [ ] Verify all version references are consistent across docs