### PR TITLE
ci: add descriptive job names and build all components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,12 +80,41 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   build:
-    name: Build
+    name: Build ${{ matrix.component.name }} (${{ matrix.goos }}, ${{ matrix.goarch }})
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         goos: [linux, darwin]
         goarch: [amd64, arm64]
+        component:
+          - name: Client
+            binary: gatekey
+            cmd: gatekey
+          - name: Server
+            binary: gatekey-server
+            cmd: gatekey-server
+          - name: Gateway
+            binary: gatekey-gateway
+            cmd: gatekey-gateway
+          - name: WireGuard Gateway
+            binary: gatekey-wireguard-gateway
+            cmd: gatekey-wireguard-gateway
+          - name: Admin CLI
+            binary: gatekey-admin
+            cmd: gatekey-admin
+          - name: Hub
+            binary: gatekey-hub
+            cmd: gatekey-hub
+          - name: Mesh Gateway
+            binary: gatekey-mesh-gateway
+            cmd: gatekey-mesh-gateway
+          - name: WireGuard Hub
+            binary: gatekey-wireguard-hub
+            cmd: gatekey-wireguard-hub
+          - name: WireGuard Mesh Gateway
+            binary: gatekey-wireguard-mesh-gateway
+            cmd: gatekey-wireguard-mesh-gateway
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -96,17 +125,14 @@ jobs:
           go-version: '1.25'
           cache: true
 
-      - name: Build binaries
+      - name: Build ${{ matrix.component.name }}
         run: |
-          CGO_ENABLED=0 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w" -o bin/gatekey-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/gatekey
-          CGO_ENABLED=0 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w" -o bin/gatekey-server-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/gatekey-server
-          CGO_ENABLED=0 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w" -o bin/gatekey-gateway-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/gatekey-gateway
-          CGO_ENABLED=0 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w" -o bin/gatekey-admin-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/gatekey-admin
+          CGO_ENABLED=0 GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w" -o bin/${{ matrix.component.binary }}-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/${{ matrix.component.cmd }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v6
         with:
-          name: binaries-${{ matrix.goos }}-${{ matrix.goarch }}
+          name: ${{ matrix.component.binary }}-${{ matrix.goos }}-${{ matrix.goarch }}
           path: bin/
           retention-days: 7
 
@@ -137,8 +163,36 @@ jobs:
         run: npm run build
 
   docker:
-    name: Docker Build
+    name: Docker Build ${{ matrix.image.name }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - name: Server
+            file: Dockerfile
+            tag: gatekey-server:test
+          - name: Gateway
+            file: Dockerfile.gateway
+            tag: gatekey-gateway:test
+          - name: WireGuard Gateway
+            file: Dockerfile.wireguard-gateway
+            tag: gatekey-wireguard-gateway:test
+          - name: Hub
+            file: Dockerfile.hub
+            tag: gatekey-hub:test
+          - name: Mesh Gateway
+            file: Dockerfile.mesh-gateway
+            tag: gatekey-mesh-gateway:test
+          - name: WireGuard Hub
+            file: Dockerfile.wireguard-hub
+            tag: gatekey-wireguard-hub:test
+          - name: WireGuard Mesh Gateway
+            file: Dockerfile.wireguard-mesh-gateway
+            tag: gatekey-wireguard-mesh-gateway:test
+          - name: Web
+            file: Dockerfile.web
+            tag: gatekey-web:test
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -146,22 +200,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build server image
+      - name: Build ${{ matrix.image.name }} image
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./Dockerfile
+          file: ./${{ matrix.image.file }}
           push: false
-          tags: gatekey-server:test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build gateway image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile.gateway
-          push: false
-          tags: gatekey-gateway:test
+          tags: ${{ matrix.image.tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -620,6 +620,9 @@ Use the admin UI or API to:
 |-------|-------------|
 | [`dyetech/gatekey-server`](https://hub.docker.com/r/dyetech/gatekey-server) | Control plane (API + embedded CA) |
 | [`dyetech/gatekey-web`](https://hub.docker.com/r/dyetech/gatekey-web) | Web UI (nginx + React) |
+| [`dyetech/gatekey-gateway`](https://hub.docker.com/r/dyetech/gatekey-gateway) | OpenVPN gateway agent |
+| [`dyetech/gatekey-hub`](https://hub.docker.com/r/dyetech/gatekey-hub) | OpenVPN mesh hub |
+| [`dyetech/gatekey-mesh-gateway`](https://hub.docker.com/r/dyetech/gatekey-mesh-gateway) | OpenVPN mesh spoke |
 | [`dyetech/gatekey-wireguard-gateway`](https://hub.docker.com/r/dyetech/gatekey-wireguard-gateway) | WireGuard gateway agent |
 | [`dyetech/gatekey-wireguard-hub`](https://hub.docker.com/r/dyetech/gatekey-wireguard-hub) | WireGuard mesh hub |
 | [`dyetech/gatekey-wireguard-mesh-gateway`](https://hub.docker.com/r/dyetech/gatekey-wireguard-mesh-gateway) | WireGuard mesh spoke |


### PR DESCRIPTION
## Summary

Improve CI job visibility and ensure all 9 binaries and 8 Docker images are built. Also fix README to document all Docker images.

### Changes

**CI Workflow:**
- **Before:** 4 binaries built, 2 Docker images tested
- **After:** 9 binaries built, 8 Docker images tested

**README:**
- Added missing OpenVPN Docker images to documentation

### Build Jobs (36 total: 9 components × 4 platforms)

| Component | Platforms |
|-----------|-----------|
| Build Client | linux/darwin × amd64/arm64 |
| Build Server | linux/darwin × amd64/arm64 |
| Build Gateway | linux/darwin × amd64/arm64 |
| Build WireGuard Gateway | linux/darwin × amd64/arm64 |
| Build Admin CLI | linux/darwin × amd64/arm64 |
| Build Hub | linux/darwin × amd64/arm64 |
| Build Mesh Gateway | linux/darwin × amd64/arm64 |
| Build WireGuard Hub | linux/darwin × amd64/arm64 |
| Build WireGuard Mesh Gateway | linux/darwin × amd64/arm64 |

### Docker Jobs (8 images)

| Job Name | Dockerfile |
|----------|------------|
| Docker Build Server | Dockerfile |
| Docker Build Gateway | Dockerfile.gateway |
| Docker Build WireGuard Gateway | Dockerfile.wireguard-gateway |
| Docker Build Hub | Dockerfile.hub |
| Docker Build Mesh Gateway | Dockerfile.mesh-gateway |
| Docker Build WireGuard Hub | Dockerfile.wireguard-hub |
| Docker Build WireGuard Mesh Gateway | Dockerfile.wireguard-mesh-gateway |
| Docker Build Web | Dockerfile.web |

### README Docker Images (was missing 3)

Added:
- `dyetech/gatekey-gateway` - OpenVPN gateway agent
- `dyetech/gatekey-hub` - OpenVPN mesh hub  
- `dyetech/gatekey-mesh-gateway` - OpenVPN mesh spoke

## Test plan

- [ ] Verify all 36 build jobs complete successfully
- [ ] Verify all 8 Docker build jobs complete successfully
- [ ] Confirm job names display correctly in GitHub Actions UI