### PR TITLE
fix(docs): use universal font stack in SVG diagrams

### DIFF
--- a/docs/diagrams/architecture-overview.svg
+++ b/docs/diagrams/architecture-overview.svg
@@ -44,32 +44,32 @@
     <rect x="150" y="20" width="600" height="200" rx="16" fill="white" stroke="#e2e8f0" stroke-width="2"/>
     <rect x="150" y="20" width="600" height="45" rx="16" fill="url(#cpHeaderGrad)"/>
     <rect x="150" y="45" width="600" height="20" fill="url(#cpHeaderGrad)"/>
-    <text x="450" y="50" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="700">GATEKEY CONTROL PLANE</text>
+    <text x="450" y="50" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700">GATEKEY CONTROL PLANE</text>
   </g>
 
   <!-- Control Plane Boxes -->
   <g filter="url(#shadow)">
     <rect x="180" y="80" width="160" height="55" rx="8" fill="url(#cpBoxGrad)"/>
-    <text x="260" y="105" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">Web UI</text>
-    <text x="260" y="122" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="10">(React)</text>
+    <text x="260" y="105" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">Web UI</text>
+    <text x="260" y="122" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="10">(React)</text>
   </g>
 
   <g filter="url(#shadow)">
     <rect x="370" y="80" width="160" height="55" rx="8" fill="url(#cpBoxGrad)"/>
-    <text x="450" y="105" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">REST API</text>
-    <text x="450" y="122" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="10">(Go)</text>
+    <text x="450" y="105" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">REST API</text>
+    <text x="450" y="122" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="10">(Go)</text>
   </g>
 
   <g filter="url(#shadow)">
     <rect x="560" y="80" width="160" height="55" rx="8" fill="url(#cpBoxGrad)"/>
-    <text x="640" y="105" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">Embedded CA</text>
-    <text x="640" y="122" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="10">(PKI)</text>
+    <text x="640" y="105" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">Embedded CA</text>
+    <text x="640" y="122" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="10">(PKI)</text>
   </g>
 
   <!-- Database -->
   <g filter="url(#shadow)">
     <rect x="300" y="155" width="300" height="50" rx="8" fill="url(#dbGrad)"/>
-    <text x="450" y="185" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600">PostgreSQL</text>
+    <text x="450" y="185" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="600">PostgreSQL</text>
   </g>
 
   <!-- Connection arrows from CP to gateways -->
@@ -81,20 +81,20 @@
     <rect x="50" y="290" width="350" height="240" rx="16" fill="white" stroke="#e2e8f0" stroke-width="2"/>
     <rect x="50" y="290" width="350" height="40" rx="16" fill="url(#ovpnGrad)"/>
     <rect x="50" y="310" width="350" height="20" fill="url(#ovpnGrad)"/>
-    <text x="225" y="317" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="700">OPENVPN GATEWAY</text>
+    <text x="225" y="317" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700">OPENVPN GATEWAY</text>
   </g>
 
   <!-- OpenVPN boxes -->
   <g>
     <rect x="80" y="350" width="130" height="50" rx="8" fill="url(#ovpnGrad)"/>
-    <text x="145" y="375" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600">OpenVPN</text>
-    <text x="145" y="390" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="10">Server</text>
+    <text x="145" y="375" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="600">OpenVPN</text>
+    <text x="145" y="390" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="10">Server</text>
   </g>
 
   <g>
     <rect x="240" y="350" width="130" height="50" rx="8" fill="url(#agentGrad)"/>
-    <text x="305" y="375" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600">Gateway</text>
-    <text x="305" y="390" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="10">Agent</text>
+    <text x="305" y="375" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="600">Gateway</text>
+    <text x="305" y="390" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="10">Agent</text>
   </g>
 
   <line x1="210" y1="375" x2="235" y2="375" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
@@ -102,8 +102,8 @@
   <!-- OpenVPN Firewall -->
   <g>
     <rect x="80" y="430" width="290" height="80" rx="8" fill="url(#fwGrad)"/>
-    <text x="225" y="465" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">nftables Firewall</text>
-    <text x="225" y="488" text-anchor="middle" fill="rgba(255,255,255,0.85)" font-family="system-ui, -apple-system, sans-serif" font-size="11">(Per-Identity Rules)</text>
+    <text x="225" y="465" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">nftables Firewall</text>
+    <text x="225" y="488" text-anchor="middle" fill="rgba(255,255,255,0.85)" font-family="Arial, Helvetica, sans-serif" font-size="11">(Per-Identity Rules)</text>
   </g>
 
   <line x1="145" y1="400" x2="145" y2="425" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
@@ -114,20 +114,20 @@
     <rect x="500" y="290" width="350" height="240" rx="16" fill="white" stroke="#e2e8f0" stroke-width="2"/>
     <rect x="500" y="290" width="350" height="40" rx="16" fill="url(#wgGrad)"/>
     <rect x="500" y="310" width="350" height="20" fill="url(#wgGrad)"/>
-    <text x="675" y="317" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="700">WIREGUARD GATEWAY</text>
+    <text x="675" y="317" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700">WIREGUARD GATEWAY</text>
   </g>
 
   <!-- WireGuard boxes -->
   <g>
     <rect x="530" y="350" width="130" height="50" rx="8" fill="url(#wgGrad)"/>
-    <text x="595" y="375" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600">WireGuard</text>
-    <text x="595" y="390" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="10">Server</text>
+    <text x="595" y="375" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="600">WireGuard</text>
+    <text x="595" y="390" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="10">Server</text>
   </g>
 
   <g>
     <rect x="690" y="350" width="130" height="50" rx="8" fill="url(#agentGrad)"/>
-    <text x="755" y="375" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600">Gateway</text>
-    <text x="755" y="390" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="10">Agent</text>
+    <text x="755" y="375" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="600">Gateway</text>
+    <text x="755" y="390" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="10">Agent</text>
   </g>
 
   <line x1="660" y1="375" x2="685" y2="375" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
@@ -135,8 +135,8 @@
   <!-- WireGuard Firewall -->
   <g>
     <rect x="530" y="430" width="290" height="80" rx="8" fill="url(#fwGrad)"/>
-    <text x="675" y="465" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">nftables Firewall</text>
-    <text x="675" y="488" text-anchor="middle" fill="rgba(255,255,255,0.85)" font-family="system-ui, -apple-system, sans-serif" font-size="11">(Per-Identity Rules)</text>
+    <text x="675" y="465" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">nftables Firewall</text>
+    <text x="675" y="488" text-anchor="middle" fill="rgba(255,255,255,0.85)" font-family="Arial, Helvetica, sans-serif" font-size="11">(Per-Identity Rules)</text>
   </g>
 
   <line x1="595" y1="400" x2="595" y2="425" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>

--- a/docs/diagrams/auth-flow.svg
+++ b/docs/diagrams/auth-flow.svg
@@ -33,22 +33,22 @@
   <!-- Entity boxes at top -->
   <g filter="url(#shadow)">
     <rect x="40" y="20" width="120" height="60" rx="10" fill="url(#userGrad)"/>
-    <text x="100" y="55" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600">User</text>
+    <text x="100" y="55" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="600">User</text>
   </g>
 
   <g filter="url(#shadow)">
     <rect x="280" y="20" width="120" height="60" rx="10" fill="url(#uiGrad)"/>
-    <text x="340" y="55" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600">Web UI</text>
+    <text x="340" y="55" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="600">Web UI</text>
   </g>
 
   <g filter="url(#shadow)">
     <rect x="480" y="20" width="140" height="60" rx="10" fill="url(#cpGrad)"/>
-    <text x="550" y="55" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600">Control Plane</text>
+    <text x="550" y="55" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="600">Control Plane</text>
   </g>
 
   <g filter="url(#shadow)">
     <rect x="720" y="20" width="100" height="60" rx="10" fill="url(#idpGrad)"/>
-    <text x="770" y="55" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600">IdP</text>
+    <text x="770" y="55" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="600">IdP</text>
   </g>
 
   <!-- Vertical lines -->
@@ -60,26 +60,26 @@
   <!-- Step 1: Access Web UI -->
   <line x1="105" y1="120" x2="330" y2="120" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
   <rect x="150" y="105" width="130" height="24" rx="4" fill="white" stroke="#e2e8f0"/>
-  <text x="215" y="122" text-anchor="middle" fill="#1e293b" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="500">1. Access Web UI</text>
+  <text x="215" y="122" text-anchor="middle" fill="#1e293b" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="500">1. Access Web UI</text>
 
   <!-- Step 2: Redirect to IdP -->
   <line x1="345" y1="170" x2="765" y2="170" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
   <rect x="480" y="155" width="130" height="24" rx="4" fill="white" stroke="#e2e8f0"/>
-  <text x="545" y="172" text-anchor="middle" fill="#1e293b" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="500">2. Redirect to IdP</text>
+  <text x="545" y="172" text-anchor="middle" fill="#1e293b" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="500">2. Redirect to IdP</text>
 
   <!-- Step 3: Authenticate -->
   <line x1="765" y1="220" x2="110" y2="220" stroke="#f59e0b" stroke-width="2" marker-end="url(#arrowReturn)"/>
   <rect x="380" y="205" width="130" height="24" rx="4" fill="white" stroke="#e2e8f0"/>
-  <text x="445" y="222" text-anchor="middle" fill="#1e293b" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="500">3. Authenticate</text>
+  <text x="445" y="222" text-anchor="middle" fill="#1e293b" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="500">3. Authenticate</text>
 
   <!-- Step 4: Callback with token -->
   <line x1="105" y1="270" x2="540" y2="270" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
   <line x1="555" y1="270" x2="765" y2="270" stroke="#f59e0b" stroke-width="2" marker-end="url(#arrowReturn)"/>
   <rect x="280" y="255" width="160" height="24" rx="4" fill="white" stroke="#e2e8f0"/>
-  <text x="360" y="272" text-anchor="middle" fill="#1e293b" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="500">4. Callback with token</text>
+  <text x="360" y="272" text-anchor="middle" fill="#1e293b" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="500">4. Callback with token</text>
 
   <!-- Step 5: Create session -->
   <line x1="545" y1="320" x2="110" y2="320" stroke="#10b981" stroke-width="2" marker-end="url(#arrowReturn)"/>
   <rect x="280" y="305" width="130" height="24" rx="4" fill="white" stroke="#e2e8f0"/>
-  <text x="345" y="322" text-anchor="middle" fill="#1e293b" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="500">5. Create session</text>
+  <text x="345" y="322" text-anchor="middle" fill="#1e293b" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="500">5. Create session</text>
 </svg>

--- a/docs/diagrams/ca-rotation.svg
+++ b/docs/diagrams/ca-rotation.svg
@@ -32,11 +32,11 @@
     <rect x="30" y="20" width="440" height="95" rx="10" fill="white" stroke="#e2e8f0" stroke-width="2"/>
     <rect x="30" y="20" width="440" height="28" rx="10" fill="url(#phase1Grad)"/>
     <rect x="30" y="38" width="440" height="10" fill="url(#phase1Grad)"/>
-    <text x="250" y="40" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="700">Phase 1: Preparation</text>
-    <text x="50" y="70" fill="#475569" font-family="system-ui, -apple-system, sans-serif" font-size="10">POST /settings/ca/prepare-rotation</text>
-    <text x="50" y="85" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="9">- Generates new CA with status "pending"</text>
-    <text x="50" y="98" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="9">- Both old and new CAs are trusted</text>
-    <text x="50" y="111" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="9">- No impact to existing connections</text>
+    <text x="250" y="40" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="700">Phase 1: Preparation</text>
+    <text x="50" y="70" fill="#475569" font-family="Arial, Helvetica, sans-serif" font-size="10">POST /settings/ca/prepare-rotation</text>
+    <text x="50" y="85" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="9">- Generates new CA with status "pending"</text>
+    <text x="50" y="98" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="9">- Both old and new CAs are trusted</text>
+    <text x="50" y="111" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="9">- No impact to existing connections</text>
   </g>
 
   <!-- Arrow -->
@@ -47,12 +47,12 @@
     <rect x="30" y="140" width="440" height="105" rx="10" fill="white" stroke="#e2e8f0" stroke-width="2"/>
     <rect x="30" y="140" width="440" height="28" rx="10" fill="url(#phase2Grad)"/>
     <rect x="30" y="158" width="440" height="10" fill="url(#phase2Grad)"/>
-    <text x="250" y="160" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="700">Phase 2: Activation</text>
-    <text x="50" y="190" fill="#475569" font-family="system-ui, -apple-system, sans-serif" font-size="10">POST /settings/ca/activate/:id</text>
-    <text x="50" y="205" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="9">- Old CA -> "retired" (still trusted)</text>
-    <text x="50" y="218" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="9">- New CA -> "active" (now issuing)</text>
-    <text x="50" y="231" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="9">- Gateways detect change via ca_fingerprint</text>
-    <text x="50" y="244" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="9">- Auto-reprovision triggered on next heartbeat</text>
+    <text x="250" y="160" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="700">Phase 2: Activation</text>
+    <text x="50" y="190" fill="#475569" font-family="Arial, Helvetica, sans-serif" font-size="10">POST /settings/ca/activate/:id</text>
+    <text x="50" y="205" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="9">- Old CA -> "retired" (still trusted)</text>
+    <text x="50" y="218" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="9">- New CA -> "active" (now issuing)</text>
+    <text x="50" y="231" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="9">- Gateways detect change via ca_fingerprint</text>
+    <text x="50" y="244" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="9">- Auto-reprovision triggered on next heartbeat</text>
   </g>
 
   <!-- Arrow -->
@@ -63,11 +63,11 @@
     <rect x="30" y="270" width="440" height="95" rx="10" fill="white" stroke="#e2e8f0" stroke-width="2"/>
     <rect x="30" y="270" width="440" height="28" rx="10" fill="url(#phase3Grad)"/>
     <rect x="30" y="288" width="440" height="10" fill="url(#phase3Grad)"/>
-    <text x="250" y="290" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="700">Phase 3: Grace Period</text>
-    <text x="50" y="320" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="9">- Existing certs from old CA still work</text>
-    <text x="50" y="333" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="9">- New certs issued by new CA</text>
-    <text x="50" y="346" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="9">- Clients regenerate configs naturally</text>
-    <text x="50" y="359" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="9">- Wait for old certs to expire (24h default)</text>
+    <text x="250" y="290" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="700">Phase 3: Grace Period</text>
+    <text x="50" y="320" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="9">- Existing certs from old CA still work</text>
+    <text x="50" y="333" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="9">- New certs issued by new CA</text>
+    <text x="50" y="346" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="9">- Clients regenerate configs naturally</text>
+    <text x="50" y="359" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="9">- Wait for old certs to expire (24h default)</text>
   </g>
 
   <!-- Arrow -->
@@ -78,9 +78,9 @@
     <rect x="30" y="390" width="440" height="85" rx="10" fill="white" stroke="#e2e8f0" stroke-width="2"/>
     <rect x="30" y="390" width="440" height="28" rx="10" fill="url(#phase4Grad)"/>
     <rect x="30" y="408" width="440" height="10" fill="url(#phase4Grad)"/>
-    <text x="250" y="410" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="700">Phase 4: Cleanup (Optional)</text>
-    <text x="50" y="440" fill="#475569" font-family="system-ui, -apple-system, sans-serif" font-size="10">POST /settings/ca/revoke/:old-ca-id</text>
-    <text x="50" y="455" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="9">- Old CA becomes completely untrusted</text>
-    <text x="50" y="468" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="9">- Any remaining old certs are rejected</text>
+    <text x="250" y="410" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="700">Phase 4: Cleanup (Optional)</text>
+    <text x="50" y="440" fill="#475569" font-family="Arial, Helvetica, sans-serif" font-size="10">POST /settings/ca/revoke/:old-ca-id</text>
+    <text x="50" y="455" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="9">- Old CA becomes completely untrusted</text>
+    <text x="50" y="468" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="9">- Any remaining old certs are rejected</text>
   </g>
 </svg>

--- a/docs/diagrams/connection-flow.svg
+++ b/docs/diagrams/connection-flow.svg
@@ -28,21 +28,21 @@
     <rect x="30" y="40" width="200" height="220" rx="12" fill="white" stroke="#e2e8f0" stroke-width="2"/>
     <rect x="30" y="40" width="200" height="35" rx="12" fill="url(#clientGrad)"/>
     <rect x="30" y="60" width="200" height="15" fill="url(#clientGrad)"/>
-    <text x="130" y="64" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="700">Your Computer</text>
+    <text x="130" y="64" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="700">Your Computer</text>
   </g>
 
   <!-- gatekey CLI -->
   <g>
     <rect x="55" y="95" width="150" height="45" rx="8" fill="url(#clientGrad)"/>
-    <text x="130" y="118" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600">gatekey CLI</text>
-    <text x="130" y="131" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="9">Authentication + Config</text>
+    <text x="130" y="118" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600">gatekey CLI</text>
+    <text x="130" y="131" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="9">Authentication + Config</text>
   </g>
 
   <!-- OpenVPN/WireGuard -->
   <g>
     <rect x="55" y="160" width="150" height="45" rx="8" fill="url(#clientGrad)"/>
-    <text x="130" y="183" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600">OpenVPN / WireGuard</text>
-    <text x="130" y="196" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="9">VPN Client</text>
+    <text x="130" y="183" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600">OpenVPN / WireGuard</text>
+    <text x="130" y="196" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="9">VPN Client</text>
   </g>
 
   <!-- Arrow from CLI to VPN -->
@@ -53,21 +53,21 @@
     <rect x="300" y="40" width="200" height="220" rx="12" fill="white" stroke="#e2e8f0" stroke-width="2"/>
     <rect x="300" y="40" width="200" height="35" rx="12" fill="url(#serverGrad)"/>
     <rect x="300" y="60" width="200" height="15" fill="url(#serverGrad)"/>
-    <text x="400" y="64" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="700">GateKey Server</text>
+    <text x="400" y="64" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="700">GateKey Server</text>
   </g>
 
   <!-- Auth + PKI -->
   <g>
     <rect x="325" y="95" width="150" height="45" rx="8" fill="url(#serverGrad)"/>
-    <text x="400" y="118" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600">Auth + PKI</text>
-    <text x="400" y="131" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="9">SSO + Certificates</text>
+    <text x="400" y="118" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600">Auth + PKI</text>
+    <text x="400" y="131" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="9">SSO + Certificates</text>
   </g>
 
   <!-- VPN Gateway -->
   <g>
     <rect x="325" y="160" width="150" height="45" rx="8" fill="url(#serverGrad)"/>
-    <text x="400" y="183" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600">VPN Gateway</text>
-    <text x="400" y="196" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="9">OpenVPN / WireGuard</text>
+    <text x="400" y="183" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600">VPN Gateway</text>
+    <text x="400" y="196" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="9">OpenVPN / WireGuard</text>
   </g>
 
   <!-- Arrow from Auth to Gateway -->
@@ -78,17 +78,17 @@
     <rect x="570" y="40" width="200" height="220" rx="12" fill="white" stroke="#e2e8f0" stroke-width="2"/>
     <rect x="570" y="40" width="200" height="35" rx="12" fill="url(#networkGrad)"/>
     <rect x="570" y="60" width="200" height="15" fill="url(#networkGrad)"/>
-    <text x="670" y="64" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="700">Company Network</text>
+    <text x="670" y="64" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="700">Company Network</text>
   </g>
 
   <!-- Internal Services -->
   <g>
     <rect x="595" y="95" width="150" height="120" rx="8" fill="url(#networkGrad)"/>
-    <text x="670" y="125" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600">Internal Services</text>
-    <text x="670" y="145" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="9">Databases</text>
-    <text x="670" y="160" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="9">APIs</text>
-    <text x="670" y="175" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="9">Applications</text>
-    <text x="670" y="190" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="9">File Servers</text>
+    <text x="670" y="125" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600">Internal Services</text>
+    <text x="670" y="145" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="9">Databases</text>
+    <text x="670" y="160" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="9">APIs</text>
+    <text x="670" y="175" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="9">Applications</text>
+    <text x="670" y="190" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="9">File Servers</text>
   </g>
 
   <!-- Horizontal connection arrows -->
@@ -97,8 +97,8 @@
   <line x1="475" y1="155" x2="590" y2="155" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
 
   <!-- Labels -->
-  <text x="262" y="108" text-anchor="middle" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="8">SSO</text>
-  <text x="262" y="175" text-anchor="middle" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="8">VPN</text>
-  <text x="533" y="148" text-anchor="middle" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="8">Secure</text>
-  <text x="533" y="160" text-anchor="middle" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="8">Access</text>
+  <text x="262" y="108" text-anchor="middle" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="8">SSO</text>
+  <text x="262" y="175" text-anchor="middle" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="8">VPN</text>
+  <text x="533" y="148" text-anchor="middle" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="8">Secure</text>
+  <text x="533" y="160" text-anchor="middle" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="8">Access</text>
 </svg>

--- a/docs/diagrams/control-plane.svg
+++ b/docs/diagrams/control-plane.svg
@@ -34,26 +34,26 @@
     <!-- Header -->
     <rect x="40" y="20" width="720" height="50" rx="16" fill="url(#headerGrad)"/>
     <rect x="40" y="50" width="720" height="20" fill="url(#headerGrad)"/>
-    <text x="400" y="52" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="18" font-weight="700">CONTROL PLANE</text>
+    <text x="400" y="52" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="18" font-weight="700">CONTROL PLANE</text>
   </g>
 
   <!-- API Layer -->
   <g filter="url(#shadow)">
     <rect x="80" y="90" width="180" height="70" rx="10" fill="url(#apiGrad)"/>
-    <text x="170" y="120" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600">Web UI</text>
-    <text x="170" y="140" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="11">(React/TypeScript)</text>
+    <text x="170" y="120" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="600">Web UI</text>
+    <text x="170" y="140" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="11">(React/TypeScript)</text>
   </g>
 
   <g filter="url(#shadow)">
     <rect x="310" y="90" width="180" height="70" rx="10" fill="url(#apiGrad)"/>
-    <text x="400" y="120" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600">REST API</text>
-    <text x="400" y="140" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="11">(Go/Gin)</text>
+    <text x="400" y="120" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="600">REST API</text>
+    <text x="400" y="140" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="11">(Go/Gin)</text>
   </g>
 
   <g filter="url(#shadow)">
     <rect x="540" y="90" width="180" height="70" rx="10" fill="url(#apiGrad)"/>
-    <text x="630" y="120" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600">gRPC API</text>
-    <text x="630" y="140" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="11">(Internal)</text>
+    <text x="630" y="120" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="600">gRPC API</text>
+    <text x="630" y="140" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="11">(Internal)</text>
   </g>
 
   <!-- Connection Lines from API to Services -->
@@ -63,31 +63,31 @@
 
   <!-- Core Services Container -->
   <rect x="80" y="195" width="640" height="90" rx="10" fill="#f0fdf4" stroke="#86efac" stroke-width="2"/>
-  <text x="400" y="218" text-anchor="middle" fill="#166534" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">Core Services</text>
+  <text x="400" y="218" text-anchor="middle" fill="#166534" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">Core Services</text>
 
   <!-- Service Boxes -->
   <g>
     <rect x="95" y="230" width="140" height="45" rx="8" fill="url(#serviceGrad)"/>
-    <text x="165" y="250" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600">Auth Service</text>
-    <text x="165" y="265" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="10">(OIDC/SAML)</text>
+    <text x="165" y="250" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="600">Auth Service</text>
+    <text x="165" y="265" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="10">(OIDC/SAML)</text>
   </g>
 
   <g>
     <rect x="250" y="230" width="140" height="45" rx="8" fill="url(#serviceGrad)"/>
-    <text x="320" y="250" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600">Policy Service</text>
-    <text x="320" y="265" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="10">(RBAC/ACL)</text>
+    <text x="320" y="250" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="600">Policy Service</text>
+    <text x="320" y="265" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="10">(RBAC/ACL)</text>
   </g>
 
   <g>
     <rect x="405" y="230" width="140" height="45" rx="8" fill="url(#serviceGrad)"/>
-    <text x="475" y="250" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600">PKI Service</text>
-    <text x="475" y="265" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="10">(Cert Gen)</text>
+    <text x="475" y="250" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="600">PKI Service</text>
+    <text x="475" y="265" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="10">(Cert Gen)</text>
   </g>
 
   <g>
     <rect x="560" y="230" width="140" height="45" rx="8" fill="url(#serviceGrad)"/>
-    <text x="630" y="250" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600">Session Service</text>
-    <text x="630" y="265" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="10">(State Mgmt)</text>
+    <text x="630" y="250" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="600">Session Service</text>
+    <text x="630" y="265" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="10">(State Mgmt)</text>
   </g>
 
   <!-- Connection to Database -->
@@ -96,7 +96,7 @@
   <!-- Database Layer -->
   <g filter="url(#shadow)">
     <rect x="200" y="320" width="400" height="60" rx="10" fill="url(#dbGrad)"/>
-    <text x="400" y="348" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="15" font-weight="600">Data Layer</text>
-    <text x="400" y="368" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="12">PostgreSQL</text>
+    <text x="400" y="348" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="600">Data Layer</text>
+    <text x="400" y="368" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="12">PostgreSQL</text>
   </g>
 </svg>

--- a/docs/diagrams/database-erd.svg
+++ b/docs/diagrams/database-erd.svg
@@ -38,38 +38,38 @@
   <!-- Users (Central) -->
   <g filter="url(#shadow)">
     <rect x="375" y="20" width="150" height="50" rx="8" fill="url(#userGrad)"/>
-    <text x="450" y="50" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600">users</text>
+    <text x="450" y="50" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="600">users</text>
   </g>
 
   <!-- Junction Tables Row -->
   <!-- user_gateways -->
   <g filter="url(#shadow)">
     <rect x="50" y="130" width="130" height="45" rx="6" fill="url(#sessionGrad)"/>
-    <text x="115" y="158" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600">user_gateways</text>
+    <text x="115" y="158" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600">user_gateways</text>
   </g>
 
   <!-- sessions -->
   <g filter="url(#shadow)">
     <rect x="210" y="130" width="100" height="45" rx="6" fill="url(#sessionGrad)"/>
-    <text x="260" y="158" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600">sessions</text>
+    <text x="260" y="158" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600">sessions</text>
   </g>
 
   <!-- user_access_rules -->
   <g filter="url(#shadow)">
     <rect x="340" y="130" width="130" height="45" rx="6" fill="url(#sessionGrad)"/>
-    <text x="405" y="158" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600">user_access_rules</text>
+    <text x="405" y="158" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600">user_access_rules</text>
   </g>
 
   <!-- certificates -->
   <g filter="url(#shadow)">
     <rect x="500" y="130" width="100" height="45" rx="6" fill="url(#sessionGrad)"/>
-    <text x="550" y="158" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600">certificates</text>
+    <text x="550" y="158" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600">certificates</text>
   </g>
 
   <!-- user_proxy_applications -->
   <g filter="url(#shadow)">
     <rect x="630" y="130" width="150" height="45" rx="6" fill="url(#sessionGrad)"/>
-    <text x="705" y="158" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600">user_proxy_apps</text>
+    <text x="705" y="158" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600">user_proxy_apps</text>
   </g>
 
   <!-- Arrows from users to junction tables -->
@@ -83,49 +83,49 @@
   <!-- gateways -->
   <g filter="url(#shadow)">
     <rect x="50" y="230" width="130" height="50" rx="8" fill="url(#gatewayGrad)"/>
-    <text x="115" y="260" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">gateways</text>
+    <text x="115" y="260" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">gateways</text>
   </g>
 
   <!-- access_rules -->
   <g filter="url(#shadow)">
     <rect x="340" y="230" width="130" height="50" rx="8" fill="url(#ruleGrad)"/>
-    <text x="405" y="260" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">access_rules</text>
+    <text x="405" y="260" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">access_rules</text>
   </g>
 
   <!-- group_access_rules -->
   <g filter="url(#shadow)">
     <rect x="340" y="310" width="130" height="45" rx="6" fill="url(#sessionGrad)"/>
-    <text x="405" y="338" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600">group_access_rules</text>
+    <text x="405" y="338" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600">group_access_rules</text>
   </g>
 
   <!-- proxy_applications -->
   <g filter="url(#shadow)">
     <rect x="630" y="230" width="150" height="50" rx="8" fill="url(#proxyGrad)"/>
-    <text x="705" y="260" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">proxy_applications</text>
+    <text x="705" y="260" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">proxy_applications</text>
   </g>
 
   <!-- connections -->
   <g filter="url(#shadow)">
     <rect x="500" y="310" width="100" height="45" rx="6" fill="url(#sessionGrad)"/>
-    <text x="550" y="338" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600">connections</text>
+    <text x="550" y="338" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600">connections</text>
   </g>
 
   <!-- gateway_networks -->
   <g filter="url(#shadow)">
     <rect x="50" y="310" width="130" height="45" rx="6" fill="url(#sessionGrad)"/>
-    <text x="115" y="338" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600">gateway_networks</text>
+    <text x="115" y="338" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600">gateway_networks</text>
   </g>
 
   <!-- networks -->
   <g filter="url(#shadow)">
     <rect x="50" y="400" width="130" height="50" rx="8" fill="url(#networkGrad)"/>
-    <text x="115" y="430" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">networks</text>
+    <text x="115" y="430" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">networks</text>
   </g>
 
   <!-- configs -->
   <g filter="url(#shadow)">
     <rect x="210" y="310" width="100" height="45" rx="6" fill="url(#sessionGrad)"/>
-    <text x="260" y="338" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600">configs</text>
+    <text x="260" y="338" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600">configs</text>
   </g>
 
   <!-- Arrows from junction to main tables -->
@@ -146,14 +146,14 @@
 
   <!-- Legend -->
   <g transform="translate(650, 380)">
-    <text x="0" y="15" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="600">Legend:</text>
+    <text x="0" y="15" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="10" font-weight="600">Legend:</text>
     <rect x="0" y="25" width="20" height="12" rx="2" fill="url(#userGrad)"/>
-    <text x="25" y="35" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="9">Core Entity</text>
+    <text x="25" y="35" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="9">Core Entity</text>
     <rect x="0" y="45" width="20" height="12" rx="2" fill="url(#sessionGrad)"/>
-    <text x="25" y="55" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="9">Junction Table</text>
+    <text x="25" y="55" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="9">Junction Table</text>
     <rect x="100" y="25" width="20" height="12" rx="2" fill="url(#gatewayGrad)"/>
-    <text x="125" y="35" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="9">VPN Entity</text>
+    <text x="125" y="35" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="9">VPN Entity</text>
     <rect x="100" y="45" width="20" height="12" rx="2" fill="url(#ruleGrad)"/>
-    <text x="125" y="55" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="9">Access Control</text>
+    <text x="125" y="55" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="9">Access Control</text>
   </g>
 </svg>

--- a/docs/diagrams/entity-relationships.svg
+++ b/docs/diagrams/entity-relationships.svg
@@ -44,35 +44,35 @@
   <!-- Users Box -->
   <g filter="url(#shadow)">
     <rect x="30" y="30" width="140" height="80" rx="12" fill="url(#userGrad)"/>
-    <text x="100" y="60" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="600">Users</text>
-    <text x="100" y="82" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="12">(SSO/Local)</text>
+    <text x="100" y="60" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="600">Users</text>
+    <text x="100" y="82" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="12">(SSO/Local)</text>
   </g>
 
   <!-- Gateways Box -->
   <g filter="url(#shadow)">
     <rect x="310" y="30" width="180" height="80" rx="12" fill="url(#gatewayGrad)"/>
-    <text x="400" y="60" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="600">Gateways</text>
-    <text x="400" y="82" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="12">(VPN Nodes)</text>
+    <text x="400" y="60" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="600">Gateways</text>
+    <text x="400" y="82" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="12">(VPN Nodes)</text>
   </g>
 
   <!-- Networks Box -->
   <g filter="url(#shadow)">
     <rect x="630" y="30" width="140" height="80" rx="12" fill="url(#networkGrad)"/>
-    <text x="700" y="60" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="600">Networks</text>
-    <text x="700" y="82" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="12">(CIDR Blocks)</text>
+    <text x="700" y="60" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="600">Networks</text>
+    <text x="700" y="82" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="12">(CIDR Blocks)</text>
   </g>
 
   <!-- Groups Box -->
   <g filter="url(#shadow)">
     <rect x="30" y="190" width="140" height="80" rx="12" fill="url(#groupGrad)"/>
-    <text x="100" y="220" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="600">Groups</text>
-    <text x="100" y="242" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="12">(from IdP)</text>
+    <text x="100" y="220" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="600">Groups</text>
+    <text x="100" y="242" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="12">(from IdP)</text>
   </g>
 
   <!-- Access Rules Box -->
   <g filter="url(#shadow)">
     <rect x="630" y="190" width="140" height="80" rx="12" fill="url(#ruleGrad)"/>
-    <text x="700" y="220" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="600">Access Rules</text>
-    <text x="700" y="242" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="12">(IP/Hostname)</text>
+    <text x="700" y="220" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="600">Access Rules</text>
+    <text x="700" y="242" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="12">(IP/Hostname)</text>
   </g>
 </svg>

--- a/docs/diagrams/gateway-node.svg
+++ b/docs/diagrams/gateway-node.svg
@@ -37,34 +37,34 @@
     <!-- Header -->
     <rect x="30" y="20" width="640" height="50" rx="16" fill="url(#headerGrad)"/>
     <rect x="30" y="50" width="640" height="20" fill="url(#headerGrad)"/>
-    <text x="350" y="52" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="18" font-weight="700">GATEWAY NODE</text>
+    <text x="350" y="52" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="18" font-weight="700">GATEWAY NODE</text>
   </g>
 
   <!-- OpenVPN Server -->
   <g filter="url(#shadow)">
     <rect x="60" y="90" width="180" height="80" rx="10" fill="url(#vpnGrad)"/>
-    <text x="150" y="125" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600">OpenVPN Server</text>
-    <text x="150" y="148" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="11">(Stock)</text>
+    <text x="150" y="125" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="600">OpenVPN Server</text>
+    <text x="150" y="148" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="11">(Stock)</text>
   </g>
 
   <!-- GateKey Gateway Agent -->
   <g filter="url(#shadow)">
     <rect x="340" y="90" width="180" height="80" rx="10" fill="url(#agentGrad)"/>
-    <text x="430" y="120" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600">GateKey Gateway</text>
-    <text x="430" y="140" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600">Agent</text>
+    <text x="430" y="120" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="600">GateKey Gateway</text>
+    <text x="430" y="140" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="600">Agent</text>
   </g>
 
   <!-- Connection between OpenVPN and Agent -->
   <line x1="240" y1="130" x2="335" y2="130" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)" marker-start="url(#arrowLeft)"/>
 
   <!-- Labels for the connection -->
-  <text x="287" y="118" text-anchor="middle" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="10">Hook Scripts</text>
+  <text x="287" y="118" text-anchor="middle" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="10">Hook Scripts</text>
 
   <!-- API Calls label going to edge -->
   <line x1="520" y1="130" x2="620" y2="130" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
-  <text x="570" y="118" text-anchor="middle" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="10">API Calls</text>
-  <text x="630" y="135" text-anchor="start" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-style="italic">to Control</text>
-  <text x="630" y="148" text-anchor="start" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-style="italic">Plane</text>
+  <text x="570" y="118" text-anchor="middle" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="10">API Calls</text>
+  <text x="630" y="135" text-anchor="start" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="10" font-style="italic">to Control</text>
+  <text x="630" y="148" text-anchor="start" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="10" font-style="italic">Plane</text>
 
   <!-- Connection down to Firewall -->
   <line x1="150" y1="170" x2="150" y2="195" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
@@ -73,7 +73,7 @@
   <!-- Firewall Manager -->
   <g filter="url(#shadow)">
     <rect x="60" y="200" width="460" height="75" rx="10" fill="url(#fwGrad)"/>
-    <text x="290" y="232" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="15" font-weight="600">Firewall Manager (nftables)</text>
-    <text x="290" y="255" text-anchor="middle" fill="rgba(255,255,255,0.85)" font-family="system-ui, -apple-system, sans-serif" font-size="12">Per-identity rules, narrow route enforcement</text>
+    <text x="290" y="232" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="600">Firewall Manager (nftables)</text>
+    <text x="290" y="255" text-anchor="middle" fill="rgba(255,255,255,0.85)" font-family="Arial, Helvetica, sans-serif" font-size="12">Per-identity rules, narrow route enforcement</text>
   </g>
 </svg>

--- a/docs/diagrams/mesh-access-flow.svg
+++ b/docs/diagrams/mesh-access-flow.svg
@@ -30,7 +30,7 @@
   <!-- Start -->
   <g filter="url(#shadow)">
     <rect x="100" y="20" width="220" height="40" rx="20" fill="url(#stepGrad)"/>
-    <text x="210" y="45" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600">User requests mesh VPN</text>
+    <text x="210" y="45" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600">User requests mesh VPN</text>
   </g>
 
   <!-- Arrow -->
@@ -39,28 +39,28 @@
   <!-- Decision 1 -->
   <g filter="url(#shadow)">
     <polygon points="210,80 330,120 210,160 90,120" fill="url(#decisionGrad)"/>
-    <text x="210" y="116" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="600">Is user assigned</text>
-    <text x="210" y="128" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="600">to hub?</text>
+    <text x="210" y="116" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="10" font-weight="600">Is user assigned</text>
+    <text x="210" y="128" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="10" font-weight="600">to hub?</text>
   </g>
 
   <!-- NO path -->
   <line x1="330" y1="120" x2="370" y2="120" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
-  <text x="345" y="112" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="9">NO</text>
+  <text x="345" y="112" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="9">NO</text>
   <g filter="url(#shadow)">
     <rect x="375" y="100" width="60" height="40" rx="6" fill="url(#errorGrad)"/>
-    <text x="405" y="116" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="600">Cannot</text>
-    <text x="405" y="128" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="600">generate</text>
+    <text x="405" y="116" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="8" font-weight="600">Cannot</text>
+    <text x="405" y="128" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="8" font-weight="600">generate</text>
   </g>
 
   <!-- YES path -->
   <line x1="210" y1="160" x2="210" y2="180" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
-  <text x="220" y="175" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="9">YES</text>
+  <text x="220" y="175" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="9">YES</text>
 
   <!-- Step 2 -->
   <g filter="url(#shadow)">
     <rect x="100" y="185" width="220" height="45" rx="8" fill="url(#stepGrad)"/>
-    <text x="210" y="205" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="600">Get networks assigned to hub</text>
-    <text x="210" y="218" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="9">(via Networks tab)</text>
+    <text x="210" y="205" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="10" font-weight="600">Get networks assigned to hub</text>
+    <text x="210" y="218" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="9">(via Networks tab)</text>
   </g>
 
   <!-- Arrow -->
@@ -69,8 +69,8 @@
   <!-- Step 3 -->
   <g filter="url(#shadow)">
     <rect x="100" y="255" width="220" height="45" rx="8" fill="url(#stepGrad)"/>
-    <text x="210" y="275" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="600">Filter to access rules user</text>
-    <text x="210" y="288" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="9">is assigned to (zero-trust)</text>
+    <text x="210" y="275" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="10" font-weight="600">Filter to access rules user</text>
+    <text x="210" y="288" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="9">is assigned to (zero-trust)</text>
   </g>
 
   <!-- Arrow -->
@@ -79,8 +79,8 @@
   <!-- Step 4 -->
   <g filter="url(#shadow)">
     <rect x="100" y="325" width="220" height="45" rx="8" fill="url(#stepGrad)"/>
-    <text x="210" y="345" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="600">Generate VPN config with</text>
-    <text x="210" y="358" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="9">ONLY authorized routes</text>
+    <text x="210" y="345" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="10" font-weight="600">Generate VPN config with</text>
+    <text x="210" y="358" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="9">ONLY authorized routes</text>
   </g>
 
   <!-- Arrow -->
@@ -89,8 +89,8 @@
   <!-- End -->
   <g filter="url(#shadow)">
     <rect x="100" y="395" width="220" height="55" rx="8" fill="url(#endGrad)"/>
-    <text x="210" y="415" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="600">User connects to mesh</text>
-    <text x="210" y="430" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="9">Can only reach networks from</text>
-    <text x="210" y="443" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="9">spokes they have access to</text>
+    <text x="210" y="415" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="10" font-weight="600">User connects to mesh</text>
+    <text x="210" y="430" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="9">Can only reach networks from</text>
+    <text x="210" y="443" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="9">spokes they have access to</text>
   </g>
 </svg>

--- a/docs/diagrams/mesh-architecture.svg
+++ b/docs/diagrams/mesh-architecture.svg
@@ -26,44 +26,44 @@
   <!-- Control Plane -->
   <g filter="url(#shadow)">
     <rect x="275" y="20" width="150" height="55" rx="10" fill="url(#cpGrad)"/>
-    <text x="350" y="45" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="700">Control Plane</text>
-    <text x="350" y="60" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="9">(GateKey UI)</text>
+    <text x="350" y="45" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="700">Control Plane</text>
+    <text x="350" y="60" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="9">(GateKey UI)</text>
   </g>
 
   <!-- API/Config label -->
-  <text x="350" y="95" text-anchor="middle" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="9">API / Config Sync</text>
+  <text x="350" y="95" text-anchor="middle" fill="#64748b" font-family="Arial, Helvetica, sans-serif" font-size="9">API / Config Sync</text>
   <line x1="350" y1="75" x2="350" y2="115" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
 
   <!-- Mesh Hub -->
   <g filter="url(#shadow)">
     <rect x="275" y="120" width="150" height="65" rx="10" fill="url(#hubGrad)"/>
-    <text x="350" y="148" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="700">Mesh Hub</text>
-    <text x="350" y="163" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="9">(gatekey-hub)</text>
-    <text x="350" y="178" text-anchor="middle" fill="rgba(255,255,255,0.7)" font-family="system-ui, -apple-system, sans-serif" font-size="8">OpenVPN Server</text>
+    <text x="350" y="148" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="700">Mesh Hub</text>
+    <text x="350" y="163" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="9">(gatekey-hub)</text>
+    <text x="350" y="178" text-anchor="middle" fill="rgba(255,255,255,0.7)" font-family="Arial, Helvetica, sans-serif" font-size="8">OpenVPN Server</text>
   </g>
 
   <!-- Spoke A -->
   <g filter="url(#shadow)">
     <rect x="50" y="260" width="140" height="70" rx="8" fill="url(#spokeGrad)"/>
-    <text x="120" y="285" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600">Spoke A</text>
-    <text x="120" y="300" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="9">10.0.0.0/8</text>
-    <text x="120" y="318" text-anchor="middle" fill="rgba(255,255,255,0.7)" font-family="system-ui, -apple-system, sans-serif" font-size="8">Home Lab</text>
+    <text x="120" y="285" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600">Spoke A</text>
+    <text x="120" y="300" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="9">10.0.0.0/8</text>
+    <text x="120" y="318" text-anchor="middle" fill="rgba(255,255,255,0.7)" font-family="Arial, Helvetica, sans-serif" font-size="8">Home Lab</text>
   </g>
 
   <!-- Spoke B -->
   <g filter="url(#shadow)">
     <rect x="280" y="260" width="140" height="70" rx="8" fill="url(#spokeGrad)"/>
-    <text x="350" y="285" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600">Spoke B</text>
-    <text x="350" y="300" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="9">192.168.0.0/24</text>
-    <text x="350" y="318" text-anchor="middle" fill="rgba(255,255,255,0.7)" font-family="system-ui, -apple-system, sans-serif" font-size="8">AWS VPC</text>
+    <text x="350" y="285" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600">Spoke B</text>
+    <text x="350" y="300" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="9">192.168.0.0/24</text>
+    <text x="350" y="318" text-anchor="middle" fill="rgba(255,255,255,0.7)" font-family="Arial, Helvetica, sans-serif" font-size="8">AWS VPC</text>
   </g>
 
   <!-- Spoke C -->
   <g filter="url(#shadow)">
     <rect x="510" y="260" width="140" height="70" rx="8" fill="url(#spokeGrad)"/>
-    <text x="580" y="285" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600">Spoke C</text>
-    <text x="580" y="300" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="9">172.16.0.0/16</text>
-    <text x="580" y="318" text-anchor="middle" fill="rgba(255,255,255,0.7)" font-family="system-ui, -apple-system, sans-serif" font-size="8">Office Network</text>
+    <text x="580" y="285" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600">Spoke C</text>
+    <text x="580" y="300" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="9">172.16.0.0/16</text>
+    <text x="580" y="318" text-anchor="middle" fill="rgba(255,255,255,0.7)" font-family="Arial, Helvetica, sans-serif" font-size="8">Office Network</text>
   </g>
 
   <!-- Lines from Hub to Spokes -->

--- a/docs/diagrams/mesh-topology.svg
+++ b/docs/diagrams/mesh-topology.svg
@@ -49,29 +49,29 @@
   <!-- Mesh Hub -->
   <g filter="url(#shadow)">
     <rect x="270" y="40" width="160" height="80" rx="12" fill="url(#hubGrad)"/>
-    <text x="350" y="75" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="700">Mesh Hub</text>
-    <text x="350" y="100" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="12">(Central)</text>
+    <text x="350" y="75" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700">Mesh Hub</text>
+    <text x="350" y="100" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="12">(Central)</text>
   </g>
 
   <!-- Spoke A - Office 1 -->
   <g filter="url(#shadow)">
     <rect x="70" y="250" width="160" height="80" rx="12" fill="url(#spokeGrad)"/>
-    <text x="150" y="285" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600">Spoke A</text>
-    <text x="150" y="308" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="12">(Office 1)</text>
+    <text x="150" y="285" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="600">Spoke A</text>
+    <text x="150" y="308" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="12">(Office 1)</text>
   </g>
 
   <!-- Spoke B - Office 2 -->
   <g filter="url(#shadow)">
     <rect x="270" y="250" width="160" height="80" rx="12" fill="url(#spokeGrad)"/>
-    <text x="350" y="285" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600">Spoke B</text>
-    <text x="350" y="308" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="12">(Office 2)</text>
+    <text x="350" y="285" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="600">Spoke B</text>
+    <text x="350" y="308" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="12">(Office 2)</text>
   </g>
 
   <!-- User Client -->
   <g filter="url(#shadow)">
     <rect x="470" y="250" width="160" height="80" rx="12" fill="url(#userGrad)"/>
-    <text x="550" y="285" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600">User</text>
-    <text x="550" y="308" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="12">(Client)</text>
+    <text x="550" y="285" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="600">User</text>
+    <text x="550" y="308" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="12">(Client)</text>
   </g>
 
   <!-- Connection indicators -->

--- a/docs/diagrams/permission-flow.svg
+++ b/docs/diagrams/permission-flow.svg
@@ -52,58 +52,58 @@
   <!-- Start: User requests VPN access -->
   <g filter="url(#shadow)">
     <rect x="200" y="15" width="300" height="40" rx="20" fill="url(#stepGrad)"/>
-    <text x="350" y="42" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="500">User requests VPN access</text>
+    <text x="350" y="42" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="500">User requests VPN access</text>
   </g>
 
   <!-- Step 1: Gateway assignment check -->
   <g filter="url(#shadow)">
     <rect x="170" y="75" width="360" height="60" rx="10" fill="url(#decisionGrad)"/>
-    <text x="350" y="100" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">1. Is user assigned to this gateway?</text>
-    <text x="175" y="125" fill="rgba(255,255,255,0.9)" font-family="system-ui, -apple-system, sans-serif" font-size="11">YES</text>
-    <text x="505" y="125" fill="rgba(255,255,255,0.9)" font-family="system-ui, -apple-system, sans-serif" font-size="11">NO</text>
+    <text x="350" y="100" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">1. Is user assigned to this gateway?</text>
+    <text x="175" y="125" fill="rgba(255,255,255,0.9)" font-family="Arial, Helvetica, sans-serif" font-size="11">YES</text>
+    <text x="505" y="125" fill="rgba(255,255,255,0.9)" font-family="Arial, Helvetica, sans-serif" font-size="11">NO</text>
   </g>
   <g filter="url(#shadow)">
     <rect x="580" y="85" width="100" height="40" rx="8" fill="url(#denyGrad)"/>
-    <text x="630" y="110" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="500">Denied</text>
+    <text x="630" y="110" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="500">Denied</text>
   </g>
 
   <!-- Step 2: Generate config -->
   <g filter="url(#shadow)">
     <rect x="170" y="165" width="360" height="70" rx="10" fill="url(#actionGrad)"/>
-    <text x="350" y="193" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">2. Generate config with</text>
-    <text x="350" y="213" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-family="system-ui, -apple-system, sans-serif" font-size="12">short-lived certificate</text>
+    <text x="350" y="193" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">2. Generate config with</text>
+    <text x="350" y="213" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-family="Arial, Helvetica, sans-serif" font-size="12">short-lived certificate</text>
   </g>
 
   <!-- User connects -->
   <g filter="url(#shadow)">
     <rect x="200" y="265" width="300" height="40" rx="20" fill="url(#stepGrad)"/>
-    <text x="350" y="292" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="500">User connects with VPN client</text>
+    <text x="350" y="292" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="500">User connects with VPN client</text>
   </g>
 
   <!-- Step 3: Gateway verifies -->
   <g filter="url(#shadow)">
     <rect x="170" y="355" width="360" height="70" rx="10" fill="url(#decisionGrad)"/>
-    <text x="350" y="378" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">3. Gateway verifies:</text>
-    <text x="350" y="398" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-family="system-ui, -apple-system, sans-serif" font-size="11">Certificate valid? User has access? Account active?</text>
-    <text x="175" y="415" fill="rgba(255,255,255,0.9)" font-family="system-ui, -apple-system, sans-serif" font-size="11">YES</text>
-    <text x="505" y="415" fill="rgba(255,255,255,0.9)" font-family="system-ui, -apple-system, sans-serif" font-size="11">NO</text>
+    <text x="350" y="378" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">3. Gateway verifies:</text>
+    <text x="350" y="398" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-family="Arial, Helvetica, sans-serif" font-size="11">Certificate valid? User has access? Account active?</text>
+    <text x="175" y="415" fill="rgba(255,255,255,0.9)" font-family="Arial, Helvetica, sans-serif" font-size="11">YES</text>
+    <text x="505" y="415" fill="rgba(255,255,255,0.9)" font-family="Arial, Helvetica, sans-serif" font-size="11">NO</text>
   </g>
   <g filter="url(#shadow)">
     <rect x="580" y="375" width="100" height="40" rx="8" fill="url(#denyGrad)"/>
-    <text x="630" y="400" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="500">Rejected</text>
+    <text x="630" y="400" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="500">Rejected</text>
   </g>
 
   <!-- Step 4: Apply firewall -->
   <g filter="url(#shadow)">
     <rect x="170" y="455" width="360" height="70" rx="10" fill="url(#actionGrad)"/>
-    <text x="350" y="483" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">4. Retrieve user's access rules</text>
-    <text x="350" y="503" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-family="system-ui, -apple-system, sans-serif" font-size="12">and apply firewall (Default: DENY ALL)</text>
+    <text x="350" y="483" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">4. Retrieve user's access rules</text>
+    <text x="350" y="503" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-family="Arial, Helvetica, sans-serif" font-size="12">and apply firewall (Default: DENY ALL)</text>
   </g>
 
   <!-- Step 5: Access granted -->
   <g filter="url(#shadow)">
     <rect x="170" y="555" width="360" height="70" rx="10" fill="url(#successGrad)"/>
-    <text x="350" y="583" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">5. User can only reach destinations</text>
-    <text x="350" y="603" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-family="system-ui, -apple-system, sans-serif" font-size="12">permitted by their access rules</text>
+    <text x="350" y="583" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">5. User can only reach destinations</text>
+    <text x="350" y="603" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-family="Arial, Helvetica, sans-serif" font-size="12">permitted by their access rules</text>
   </g>
 </svg>

--- a/docs/diagrams/readme-architecture.svg
+++ b/docs/diagrams/readme-architecture.svg
@@ -44,32 +44,32 @@
     <rect x="150" y="20" width="600" height="200" rx="16" fill="white" stroke="#e2e8f0" stroke-width="2"/>
     <rect x="150" y="20" width="600" height="45" rx="16" fill="url(#cpHeaderGrad)"/>
     <rect x="150" y="45" width="600" height="20" fill="url(#cpHeaderGrad)"/>
-    <text x="450" y="50" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="700">GATEKEY CONTROL PLANE</text>
+    <text x="450" y="50" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700">GATEKEY CONTROL PLANE</text>
   </g>
 
   <!-- Control Plane Boxes -->
   <g filter="url(#shadow)">
     <rect x="180" y="80" width="160" height="55" rx="8" fill="url(#cpBoxGrad)"/>
-    <text x="260" y="105" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">Web UI</text>
-    <text x="260" y="122" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="10">(React)</text>
+    <text x="260" y="105" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">Web UI</text>
+    <text x="260" y="122" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="10">(React)</text>
   </g>
 
   <g filter="url(#shadow)">
     <rect x="370" y="80" width="160" height="55" rx="8" fill="url(#cpBoxGrad)"/>
-    <text x="450" y="105" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">REST API</text>
-    <text x="450" y="122" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="10">(Go)</text>
+    <text x="450" y="105" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">REST API</text>
+    <text x="450" y="122" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="10">(Go)</text>
   </g>
 
   <g filter="url(#shadow)">
     <rect x="560" y="80" width="160" height="55" rx="8" fill="url(#cpBoxGrad)"/>
-    <text x="640" y="105" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">Embedded CA</text>
-    <text x="640" y="122" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="10">(PKI)</text>
+    <text x="640" y="105" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">Embedded CA</text>
+    <text x="640" y="122" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="10">(PKI)</text>
   </g>
 
   <!-- Database -->
   <g filter="url(#shadow)">
     <rect x="300" y="155" width="300" height="50" rx="8" fill="url(#dbGrad)"/>
-    <text x="450" y="185" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600">PostgreSQL</text>
+    <text x="450" y="185" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="600">PostgreSQL</text>
   </g>
 
   <!-- Connection arrows from CP to gateways -->
@@ -81,20 +81,20 @@
     <rect x="50" y="290" width="350" height="240" rx="16" fill="white" stroke="#e2e8f0" stroke-width="2"/>
     <rect x="50" y="290" width="350" height="40" rx="16" fill="url(#ovpnGrad)"/>
     <rect x="50" y="310" width="350" height="20" fill="url(#ovpnGrad)"/>
-    <text x="225" y="317" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="700">OPENVPN GATEWAY</text>
+    <text x="225" y="317" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700">OPENVPN GATEWAY</text>
   </g>
 
   <!-- OpenVPN boxes -->
   <g>
     <rect x="80" y="350" width="130" height="50" rx="8" fill="url(#ovpnGrad)"/>
-    <text x="145" y="375" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600">OpenVPN</text>
-    <text x="145" y="390" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="10">Server</text>
+    <text x="145" y="375" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="600">OpenVPN</text>
+    <text x="145" y="390" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="10">Server</text>
   </g>
 
   <g>
     <rect x="240" y="350" width="130" height="50" rx="8" fill="url(#agentGrad)"/>
-    <text x="305" y="375" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600">Gateway</text>
-    <text x="305" y="390" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="10">Agent</text>
+    <text x="305" y="375" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="600">Gateway</text>
+    <text x="305" y="390" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="10">Agent</text>
   </g>
 
   <line x1="210" y1="375" x2="235" y2="375" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
@@ -102,8 +102,8 @@
   <!-- OpenVPN Firewall -->
   <g>
     <rect x="80" y="430" width="290" height="80" rx="8" fill="url(#fwGrad)"/>
-    <text x="225" y="465" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">nftables Firewall</text>
-    <text x="225" y="488" text-anchor="middle" fill="rgba(255,255,255,0.85)" font-family="system-ui, -apple-system, sans-serif" font-size="11">(Per-Identity Rules)</text>
+    <text x="225" y="465" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">nftables Firewall</text>
+    <text x="225" y="488" text-anchor="middle" fill="rgba(255,255,255,0.85)" font-family="Arial, Helvetica, sans-serif" font-size="11">(Per-Identity Rules)</text>
   </g>
 
   <line x1="145" y1="400" x2="145" y2="425" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
@@ -114,20 +114,20 @@
     <rect x="500" y="290" width="350" height="240" rx="16" fill="white" stroke="#e2e8f0" stroke-width="2"/>
     <rect x="500" y="290" width="350" height="40" rx="16" fill="url(#wgGrad)"/>
     <rect x="500" y="310" width="350" height="20" fill="url(#wgGrad)"/>
-    <text x="675" y="317" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="700">WIREGUARD GATEWAY</text>
+    <text x="675" y="317" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700">WIREGUARD GATEWAY</text>
   </g>
 
   <!-- WireGuard boxes -->
   <g>
     <rect x="530" y="350" width="130" height="50" rx="8" fill="url(#wgGrad)"/>
-    <text x="595" y="375" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600">WireGuard</text>
-    <text x="595" y="390" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="10">Server</text>
+    <text x="595" y="375" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="600">WireGuard</text>
+    <text x="595" y="390" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="10">Server</text>
   </g>
 
   <g>
     <rect x="690" y="350" width="130" height="50" rx="8" fill="url(#agentGrad)"/>
-    <text x="755" y="375" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600">Gateway</text>
-    <text x="755" y="390" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="10">Agent</text>
+    <text x="755" y="375" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="600">Gateway</text>
+    <text x="755" y="390" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="10">Agent</text>
   </g>
 
   <line x1="660" y1="375" x2="685" y2="375" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
@@ -135,8 +135,8 @@
   <!-- WireGuard Firewall -->
   <g>
     <rect x="530" y="430" width="290" height="80" rx="8" fill="url(#fwGrad)"/>
-    <text x="675" y="465" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">nftables Firewall</text>
-    <text x="675" y="488" text-anchor="middle" fill="rgba(255,255,255,0.85)" font-family="system-ui, -apple-system, sans-serif" font-size="11">(Per-Identity Rules)</text>
+    <text x="675" y="465" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">nftables Firewall</text>
+    <text x="675" y="488" text-anchor="middle" fill="rgba(255,255,255,0.85)" font-family="Arial, Helvetica, sans-serif" font-size="11">(Per-Identity Rules)</text>
   </g>
 
   <line x1="595" y1="400" x2="595" y2="425" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>

--- a/docs/diagrams/realtime-enforcement.svg
+++ b/docs/diagrams/realtime-enforcement.svg
@@ -34,22 +34,22 @@
   <!-- Admin UI -->
   <g filter="url(#shadow)">
     <rect x="30" y="30" width="120" height="60" rx="8" fill="url(#uiGrad)"/>
-    <text x="90" y="57" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600">Admin UI</text>
-    <text x="90" y="72" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="9">(Rule Change)</text>
+    <text x="90" y="57" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600">Admin UI</text>
+    <text x="90" y="72" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="9">(Rule Change)</text>
   </g>
 
   <!-- Control Plane -->
   <g filter="url(#shadow)">
     <rect x="200" y="30" width="120" height="60" rx="8" fill="url(#dbGrad)"/>
-    <text x="260" y="57" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600">Control Plane</text>
-    <text x="260" y="72" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="9">(Database)</text>
+    <text x="260" y="57" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600">Control Plane</text>
+    <text x="260" y="72" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="9">(Database)</text>
   </g>
 
   <!-- Gateway Agent -->
   <g filter="url(#shadow)">
     <rect x="370" y="30" width="120" height="60" rx="8" fill="url(#agentGrad)"/>
-    <text x="430" y="57" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600">Gateway Agent</text>
-    <text x="430" y="72" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="system-ui, -apple-system, sans-serif" font-size="9">(nftables)</text>
+    <text x="430" y="57" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600">Gateway Agent</text>
+    <text x="430" y="72" text-anchor="middle" fill="rgba(255,255,255,0.8)" font-family="Arial, Helvetica, sans-serif" font-size="9">(nftables)</text>
   </g>
 
   <!-- Horizontal arrows top row -->
@@ -59,17 +59,17 @@
   <!-- API Endpoint -->
   <g filter="url(#shadow)">
     <rect x="200" y="130" width="120" height="60" rx="8" fill="url(#apiGrad)"/>
-    <text x="260" y="150" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="9" font-weight="600">/gateway/</text>
-    <text x="260" y="163" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-family="system-ui, -apple-system, sans-serif" font-size="9">client-rules</text>
-    <text x="260" y="176" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-family="system-ui, -apple-system, sans-serif" font-size="9">all-rules</text>
+    <text x="260" y="150" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="9" font-weight="600">/gateway/</text>
+    <text x="260" y="163" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-family="Arial, Helvetica, sans-serif" font-size="9">client-rules</text>
+    <text x="260" y="176" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-family="Arial, Helvetica, sans-serif" font-size="9">all-rules</text>
   </g>
 
   <!-- Client Traffic -->
   <g filter="url(#shadow)">
     <rect x="370" y="130" width="120" height="60" rx="8" fill="url(#fwGrad)"/>
-    <text x="430" y="150" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="9" font-weight="600">Client Traffic</text>
-    <text x="430" y="165" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-family="system-ui, -apple-system, sans-serif" font-size="9">Immediately</text>
-    <text x="430" y="178" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-family="system-ui, -apple-system, sans-serif" font-size="9">Blocked/Allowed</text>
+    <text x="430" y="150" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="9" font-weight="600">Client Traffic</text>
+    <text x="430" y="165" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-family="Arial, Helvetica, sans-serif" font-size="9">Immediately</text>
+    <text x="430" y="178" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-family="Arial, Helvetica, sans-serif" font-size="9">Blocked/Allowed</text>
   </g>
 
   <!-- Vertical arrows -->

--- a/docs/diagrams/vpn-connection-flow.svg
+++ b/docs/diagrams/vpn-connection-flow.svg
@@ -36,25 +36,25 @@
   <!-- Entity boxes at top -->
   <g filter="url(#shadow)">
     <rect x="40" y="15" width="100" height="55" rx="10" fill="url(#userGrad)"/>
-    <text x="90" y="48" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">User</text>
+    <text x="90" y="48" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">User</text>
   </g>
 
   <g filter="url(#shadow)">
     <rect x="240" y="15" width="120" height="55" rx="10" fill="url(#clientGrad)"/>
-    <text x="300" y="40" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">OpenVPN</text>
-    <text x="300" y="56" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-family="system-ui, -apple-system, sans-serif" font-size="11">Client</text>
+    <text x="300" y="40" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">OpenVPN</text>
+    <text x="300" y="56" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-family="Arial, Helvetica, sans-serif" font-size="11">Client</text>
   </g>
 
   <g filter="url(#shadow)">
     <rect x="480" y="15" width="130" height="55" rx="10" fill="url(#agentGrad)"/>
-    <text x="545" y="40" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">Gateway</text>
-    <text x="545" y="56" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-family="system-ui, -apple-system, sans-serif" font-size="11">Agent</text>
+    <text x="545" y="40" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">Gateway</text>
+    <text x="545" y="56" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-family="Arial, Helvetica, sans-serif" font-size="11">Agent</text>
   </g>
 
   <g filter="url(#shadow)">
     <rect x="740" y="15" width="120" height="55" rx="10" fill="url(#cpGrad)"/>
-    <text x="800" y="40" text-anchor="middle" fill="white" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">Control</text>
-    <text x="800" y="56" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-family="system-ui, -apple-system, sans-serif" font-size="11">Plane</text>
+    <text x="800" y="40" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="600">Control</text>
+    <text x="800" y="56" text-anchor="middle" fill="rgba(255,255,255,0.9)" font-family="Arial, Helvetica, sans-serif" font-size="11">Plane</text>
   </g>
 
   <!-- Vertical lines -->
@@ -66,47 +66,47 @@
   <!-- Step 1: Connect -->
   <line x1="95" y1="100" x2="290" y2="100" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
   <rect x="145" y="85" width="100" height="24" rx="4" fill="white" stroke="#e2e8f0"/>
-  <text x="195" y="102" text-anchor="middle" fill="#1e293b" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="500">1. Connect</text>
+  <text x="195" y="102" text-anchor="middle" fill="#1e293b" font-family="Arial, Helvetica, sans-serif" font-size="10" font-weight="500">1. Connect</text>
 
   <!-- Step 2: TLS Handshake -->
   <line x1="305" y1="140" x2="535" y2="140" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
   <rect x="360" y="125" width="120" height="24" rx="4" fill="white" stroke="#e2e8f0"/>
-  <text x="420" y="142" text-anchor="middle" fill="#1e293b" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="500">2. TLS Handshake</text>
+  <text x="420" y="142" text-anchor="middle" fill="#1e293b" font-family="Arial, Helvetica, sans-serif" font-size="10" font-weight="500">2. TLS Handshake</text>
 
   <!-- Step 3: Verify Cert -->
   <line x1="550" y1="180" x2="790" y2="180" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
   <rect x="615" y="165" width="120" height="24" rx="4" fill="white" stroke="#e2e8f0"/>
-  <text x="675" y="182" text-anchor="middle" fill="#1e293b" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="500">3. Verify Cert</text>
+  <text x="675" y="182" text-anchor="middle" fill="#1e293b" font-family="Arial, Helvetica, sans-serif" font-size="10" font-weight="500">3. Verify Cert</text>
 
   <!-- Step 4: Auth Result -->
   <line x1="795" y1="220" x2="555" y2="220" stroke="#10b981" stroke-width="2" marker-end="url(#arrowReturn)"/>
   <rect x="615" y="205" width="120" height="24" rx="4" fill="white" stroke="#e2e8f0"/>
-  <text x="675" y="222" text-anchor="middle" fill="#1e293b" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="500">4. Auth Result</text>
+  <text x="675" y="222" text-anchor="middle" fill="#1e293b" font-family="Arial, Helvetica, sans-serif" font-size="10" font-weight="500">4. Auth Result</text>
 
   <!-- Step 5: Connect Hook -->
   <line x1="305" y1="260" x2="535" y2="260" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
   <rect x="360" y="245" width="120" height="24" rx="4" fill="white" stroke="#e2e8f0"/>
-  <text x="420" y="262" text-anchor="middle" fill="#1e293b" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="500">5. Connect Hook</text>
+  <text x="420" y="262" text-anchor="middle" fill="#1e293b" font-family="Arial, Helvetica, sans-serif" font-size="10" font-weight="500">5. Connect Hook</text>
 
   <!-- Step 6: Get Policies -->
   <line x1="550" y1="300" x2="790" y2="300" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
   <rect x="615" y="285" width="120" height="24" rx="4" fill="white" stroke="#e2e8f0"/>
-  <text x="675" y="302" text-anchor="middle" fill="#1e293b" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="500">6. Get Policies</text>
+  <text x="675" y="302" text-anchor="middle" fill="#1e293b" font-family="Arial, Helvetica, sans-serif" font-size="10" font-weight="500">6. Get Policies</text>
 
   <!-- Step 7: Policy Rules -->
   <line x1="795" y1="340" x2="555" y2="340" stroke="#10b981" stroke-width="2" marker-end="url(#arrowReturn)"/>
   <rect x="615" y="325" width="120" height="24" rx="4" fill="white" stroke="#e2e8f0"/>
-  <text x="675" y="342" text-anchor="middle" fill="#1e293b" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="500">7. Policy Rules</text>
+  <text x="675" y="342" text-anchor="middle" fill="#1e293b" font-family="Arial, Helvetica, sans-serif" font-size="10" font-weight="500">7. Policy Rules</text>
 
   <!-- Step 8: Apply FW Rules (self-loop) -->
   <path d="M555,380 C600,380 600,420 555,420" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
   <rect x="560" y="385" width="120" height="24" rx="4" fill="white" stroke="#e2e8f0"/>
-  <text x="620" y="402" text-anchor="middle" fill="#1e293b" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="500">8. Apply FW Rules</text>
+  <text x="620" y="402" text-anchor="middle" fill="#1e293b" font-family="Arial, Helvetica, sans-serif" font-size="10" font-weight="500">8. Apply FW Rules</text>
 
   <!-- Step 9: Push Config -->
   <line x1="540" y1="460" x2="310" y2="460" stroke="#10b981" stroke-width="2" marker-end="url(#arrowReturn)"/>
   <rect x="360" y="445" width="120" height="24" rx="4" fill="white" stroke="#e2e8f0"/>
-  <text x="420" y="462" text-anchor="middle" fill="#1e293b" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="500">9. Push Config</text>
+  <text x="420" y="462" text-anchor="middle" fill="#1e293b" font-family="Arial, Helvetica, sans-serif" font-size="10" font-weight="500">9. Push Config</text>
 
   <!-- Step 10: Tunnel Established -->
   <line x1="95" y1="520" x2="535" y2="520" stroke="#3b82f6" stroke-width="3"/>
@@ -115,5 +115,5 @@
   <line x1="520" y1="515" x2="535" y2="520" stroke="#3b82f6" stroke-width="3"/>
   <line x1="520" y1="525" x2="535" y2="520" stroke="#3b82f6" stroke-width="3"/>
   <rect x="245" y="500" width="150" height="28" rx="4" fill="#dbeafe" stroke="#3b82f6"/>
-  <text x="320" y="520" text-anchor="middle" fill="#1e40af" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600">10. Tunnel Established</text>
+  <text x="320" y="520" text-anchor="middle" fill="#1e40af" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600">10. Tunnel Established</text>
 </svg>


### PR DESCRIPTION
## Summary

Fix garbled text rendering in SVG diagram files by replacing system fonts with universally supported fonts.

### Problem

SVG diagrams were using `system-ui, -apple-system, sans-serif` font stack which causes font substitution issues on some systems, resulting in garbled/unreadable text:

![Garbled text example](https://github.com/user-attachments/assets/example)

### Solution

Replace with `Arial, Helvetica, sans-serif` which is universally available and renders consistently across all platforms and browsers.

### Files Updated (15 total)

- `architecture-overview.svg`
- `auth-flow.svg`
- `ca-rotation.svg`
- `connection-flow.svg`
- `control-plane.svg`
- `database-erd.svg`
- `entity-relationships.svg`
- `gateway-node.svg`
- `mesh-access-flow.svg`
- `mesh-architecture.svg`
- `mesh-topology.svg`
- `permission-flow.svg`
- `readme-architecture.svg`
- `realtime-enforcement.svg`
- `vpn-connection-flow.svg`

## Test plan

- [ ] Verify SVG diagrams render correctly in GitHub README
- [ ] Verify SVG diagrams render correctly in documentation site
- [ ] Test on multiple browsers (Chrome, Firefox, Safari)