### PR TITLE
docs(readme): add permission flow diagram to Security Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,10 @@ See [docs/api.md](docs/api.md) for full API documentation.
 
 # Security Features
 
+GateKey implements a **Zero Trust** security model where all traffic is denied by default. Users can only access resources explicitly permitted by their access rules.
+
+![Permission Flow](docs/diagrams/permission-flow.svg)
+
 - **Zero Trust**: No network access without authentication
 - **Short-Lived Certificates**: Auto-expire after 24 hours (configurable)
 - **Per-Identity Firewall**: Each user gets their own firewall rules (nftables)


### PR DESCRIPTION
## Summary
- Add zero-trust permission flow diagram to README Security Features section
- Add introductory text explaining the default-deny security model

This makes the security model more visible and easier to understand for new users visiting the repo.

## Test plan
- [ ] Verify diagram renders correctly on GitHub
- [x] Check diagram displays properly in README preview