### PR TITLE
fix(api): use correct content-type for WireGuard config downloads

### DIFF
--- a/internal/api/mesh_handlers.go
+++ b/internal/api/mesh_handlers.go
@@ -2940,9 +2940,16 @@ func (s *Server) handleDownloadMeshConfig(c *gin.Context) {
 	// Mark as downloaded
 	_ = s.meshConfigStore.MarkDownloaded(c.Request.Context(), configID)
 
+	// Determine content type based on hub's gateway type
+	contentType := "application/x-openvpn-profile"
+	hub, err := s.meshStore.GetHub(c.Request.Context(), config.HubID)
+	if err == nil && hub.GatewayType == db.MeshGatewayTypeWireGuard {
+		contentType = "application/x-wireguard-profile"
+	}
+
 	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%s", config.FileName))
-	c.Header("Content-Type", "application/x-openvpn-profile")
-	c.Data(http.StatusOK, "application/x-openvpn-profile", config.ConfigData)
+	c.Header("Content-Type", contentType)
+	c.Data(http.StatusOK, contentType, config.ConfigData)
 }
 
 // ==================== Admin Mesh Config Management ====================

--- a/internal/api/wireguard_handlers.go
+++ b/internal/api/wireguard_handlers.go
@@ -369,7 +369,8 @@ func (s *Server) handleDownloadWireGuardConfig(c *gin.Context) {
 	}
 
 	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%s", config.FileName))
-	c.Data(http.StatusOK, "text/plain", config.ConfigData)
+	c.Header("Content-Type", "application/x-wireguard-profile")
+	c.Data(http.StatusOK, "application/x-wireguard-profile", config.ConfigData)
 }
 
 // handleRevokeWireGuardConfig allows a user to revoke their own config

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1677,6 +1677,7 @@ export interface UserMeshHub {
   id: string
   name: string
   description: string
+  hubType: 'openvpn' | 'wireguard'
   status: string
   connectedspokes: number
 }
@@ -1700,6 +1701,16 @@ export interface MeshClientConfigWithId {
 
 export async function generateMeshClientConfig(hubId: string): Promise<MeshClientConfigWithId> {
   const response = await api.post('/api/v1/mesh/generate-config', { hubid: hubId })
+  return {
+    id: response.data.id,
+    hubname: response.data.hubname,
+    config: response.data.config,
+    expiresAt: response.data.expiresAt,
+  }
+}
+
+export async function generateWireGuardMeshClientConfig(hubId: string): Promise<MeshClientConfigWithId> {
+  const response = await api.post('/api/v1/mesh/wireguard/generate-config', { hubid: hubId })
   return {
     id: response.data.id,
     hubname: response.data.hubname,

--- a/web/src/pages/Connect.tsx
+++ b/web/src/pages/Connect.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useSearchParams, Link } from 'react-router-dom'
-import { getGateways, generateConfig, generateWireGuardConfig, getUserMeshHubs, generateMeshClientConfig, Gateway, GeneratedConfig, GeneratedWireGuardConfig, UserMeshHub } from '../api/client'
+import { getGateways, generateConfig, generateWireGuardConfig, getUserMeshHubs, generateMeshClientConfig, generateWireGuardMeshClientConfig, Gateway, GeneratedConfig, GeneratedWireGuardConfig, UserMeshHub } from '../api/client'
 import { useAuth } from '../contexts/AuthContext'
 
 type ConnectionType = 'gateways' | 'mesh'
@@ -96,7 +96,10 @@ export default function Connect() {
     setError(null)
 
     try {
-      const config = await generateMeshClientConfig(selectedMeshHub.id)
+      // Use the appropriate endpoint based on hub type
+      const config = selectedMeshHub.hubType === 'wireguard'
+        ? await generateWireGuardMeshClientConfig(selectedMeshHub.id)
+        : await generateMeshClientConfig(selectedMeshHub.id)
       setMeshConfig(config)
     } catch (err) {
       setError('Failed to generate mesh configuration')
@@ -106,12 +109,15 @@ export default function Connect() {
   }
 
   function handleMeshDownload() {
-    if (!meshConfig) return
-    const blob = new Blob([meshConfig.config], { type: 'application/x-openvpn-profile' })
+    if (!meshConfig || !selectedMeshHub) return
+    const isWireGuard = selectedMeshHub.hubType === 'wireguard'
+    const mimeType = isWireGuard ? 'application/x-wireguard-profile' : 'application/x-openvpn-profile'
+    const extension = isWireGuard ? 'conf' : 'ovpn'
+    const blob = new Blob([meshConfig.config], { type: mimeType })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
-    a.download = `mesh-${meshConfig.hubname}.ovpn`
+    a.download = `mesh-${meshConfig.hubname}.${extension}`
     document.body.appendChild(a)
     a.click()
     document.body.removeChild(a)
@@ -669,7 +675,11 @@ export default function Connect() {
               >
                 <div>
                   <h2 className="text-lg font-semibold text-theme-primary">Manual Configuration</h2>
-                  <p className="text-sm text-theme-tertiary">Download an OpenVPN config file for use with any OpenVPN client</p>
+                  <p className="text-sm text-theme-tertiary">
+                    {selectedMeshHub?.hubType === 'wireguard'
+                      ? 'Download a WireGuard config file for use with any WireGuard client'
+                      : 'Download an OpenVPN config file for use with any OpenVPN client'}
+                  </p>
                 </div>
                 <svg
                   className={`w-5 h-5 text-theme-muted transition-transform ${showManualDownload ? 'rotate-180' : ''}`}
@@ -734,30 +744,61 @@ export default function Connect() {
 
                       {/* Platform-specific instructions */}
                       <div className="grid grid-cols-1 md:grid-cols-3 gap-4 pt-4">
-                        <div>
-                          <h3 className="font-medium text-theme-primary mb-2">Windows</h3>
-                          <ol className="text-sm text-theme-secondary space-y-1">
-                            <li>1. Download OpenVPN GUI</li>
-                            <li>2. Import the .ovpn file</li>
-                            <li>3. Right-click tray icon &rarr; Connect</li>
-                          </ol>
-                        </div>
-                        <div>
-                          <h3 className="font-medium text-theme-primary mb-2">macOS</h3>
-                          <ol className="text-sm text-theme-secondary space-y-1">
-                            <li>1. Install Tunnelblick or OpenVPN Connect</li>
-                            <li>2. Double-click the .ovpn file</li>
-                            <li>3. Click Connect</li>
-                          </ol>
-                        </div>
-                        <div>
-                          <h3 className="font-medium text-theme-primary mb-2">Linux</h3>
-                          <ol className="text-sm text-theme-secondary space-y-1">
-                            <li>1. Install openvpn package</li>
-                            <li>2. Run: sudo openvpn config.ovpn</li>
-                            <li>3. Or import to NetworkManager</li>
-                          </ol>
-                        </div>
+                        {selectedMeshHub?.hubType === 'wireguard' ? (
+                          <>
+                            <div>
+                              <h3 className="font-medium text-theme-primary mb-2">Windows</h3>
+                              <ol className="text-sm text-theme-secondary space-y-1">
+                                <li>1. Download WireGuard from wireguard.com</li>
+                                <li>2. Import the .conf file</li>
+                                <li>3. Click Activate</li>
+                              </ol>
+                            </div>
+                            <div>
+                              <h3 className="font-medium text-theme-primary mb-2">macOS</h3>
+                              <ol className="text-sm text-theme-secondary space-y-1">
+                                <li>1. Install WireGuard from App Store</li>
+                                <li>2. Import tunnel from file</li>
+                                <li>3. Click Activate</li>
+                              </ol>
+                            </div>
+                            <div>
+                              <h3 className="font-medium text-theme-primary mb-2">Linux</h3>
+                              <ol className="text-sm text-theme-secondary space-y-1">
+                                <li>1. Install wireguard-tools package</li>
+                                <li>2. Run: sudo wg-quick up ./config.conf</li>
+                                <li>3. Or import to NetworkManager</li>
+                              </ol>
+                            </div>
+                          </>
+                        ) : (
+                          <>
+                            <div>
+                              <h3 className="font-medium text-theme-primary mb-2">Windows</h3>
+                              <ol className="text-sm text-theme-secondary space-y-1">
+                                <li>1. Download OpenVPN GUI</li>
+                                <li>2. Import the .ovpn file</li>
+                                <li>3. Right-click tray icon &rarr; Connect</li>
+                              </ol>
+                            </div>
+                            <div>
+                              <h3 className="font-medium text-theme-primary mb-2">macOS</h3>
+                              <ol className="text-sm text-theme-secondary space-y-1">
+                                <li>1. Install Tunnelblick or OpenVPN Connect</li>
+                                <li>2. Double-click the .ovpn file</li>
+                                <li>3. Click Connect</li>
+                              </ol>
+                            </div>
+                            <div>
+                              <h3 className="font-medium text-theme-primary mb-2">Linux</h3>
+                              <ol className="text-sm text-theme-secondary space-y-1">
+                                <li>1. Install openvpn package</li>
+                                <li>2. Run: sudo openvpn config.ovpn</li>
+                                <li>3. Or import to NetworkManager</li>
+                              </ol>
+                            </div>
+                          </>
+                        )}
                       </div>
                     </div>
                   ) : (
@@ -793,7 +834,7 @@ export default function Connect() {
                   <strong>Hub:</strong> {meshConfig.hubname}
                 </p>
                 <p className="text-sm text-theme-secondary">
-                  <strong>File:</strong> mesh-{meshConfig.hubname}.ovpn
+                  <strong>File:</strong> mesh-{meshConfig.hubname}.{selectedMeshHub?.hubType === 'wireguard' ? 'conf' : 'ovpn'}
                 </p>
               </div>
               <div className="flex space-x-3">


### PR DESCRIPTION
## Summary
- Fix WireGuard mesh configs incorrectly downloading as `.ovpn` files
- Fix WireGuard gateway configs using `text/plain` instead of proper MIME type

## Problem
When connecting to a WireGuard mesh network or gateway, the downloaded config file was incorrectly served with OpenVPN content-type headers, causing:
- Wrong file extension (`.ovpn` instead of `.conf`)
- OS file associations not working correctly
- Confusion for users expecting WireGuard config format

## Changes
- **mesh_handlers.go**: Look up hub gateway type and use `application/x-wireguard-profile` for WireGuard hubs
- **wireguard_handlers.go**: Use `application/x-wireguard-profile` instead of `text/plain`
- **client.ts**: Add `hubType` field to `UserMeshHub` interface
- **Connect.tsx**: Check hub type and use correct file extension (`.conf`) and MIME type for WireGuard

## Test plan
- [x] Connect to WireGuard mesh hub and verify config downloads as `.conf`
- [x] Connect to WireGuard gateway and verify config downloads as `.conf`
- [x] Connect to OpenVPN mesh hub and verify config still downloads as `.ovpn`
- [x] Connect to OpenVPN gateway and verify config still downloads as `.ovpn`