### PR TITLE
fix(web): add missing nginx proxy routes for backend endpoints

### DIFF
--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -28,4 +28,78 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
+
+    # Proxy install scripts to backend
+    location /scripts/ {
+        proxy_pass http://gatekey-server:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Proxy install.sh alias
+    location = /install.sh {
+        proxy_pass http://gatekey-server:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Proxy binary downloads
+    location /downloads {
+        proxy_pass http://gatekey-server:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /bin/ {
+        proxy_pass http://gatekey-server:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Health check endpoints
+    location /health {
+        proxy_pass http://gatekey-server:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location /ready {
+        proxy_pass http://gatekey-server:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location /live {
+        proxy_pass http://gatekey-server:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # WebSocket endpoints
+    location /ws/ {
+        proxy_pass http://gatekey-server:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 86400;
+    }
 }


### PR DESCRIPTION
## Summary

- Add proxy rules for `/scripts/*` install scripts
- Add proxy rules for `/install.sh` alias
- Add proxy rules for `/downloads/*` and `/bin/*` binary downloads
- Add proxy rules for `/health`, `/ready`, `/live` health check endpoints
- Add proxy rules for `/ws/*` WebSocket endpoints with upgrade support

## Problem

The gatekey-web nginx config only proxied `/api/` to the backend server. Other endpoints served by gatekey-server (like install scripts) returned 404 errors:

```bash
curl -sSL https://gatekey.example.com/scripts/install-wireguard-hub.sh
# 404 Not Found
```

## Test plan

- [ ] Verify install scripts are accessible: `curl https://gatekey.example.com/scripts/install-gateway.sh`
- [x] Verify health endpoint works: `curl https://gatekey.example.com/health`
- [x] Verify WebSocket connections work in admin panel