### PR TITLE
fix(docker): include install scripts in server image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ WORKDIR /app
 
 COPY --from=builder /app-binary /app/gatekey
 
+# Copy install scripts for server
+COPY --from=builder /app/scripts /app/scripts
+
 # Server listens on 8080
 EXPOSE 8080
 


### PR DESCRIPTION
## Summary
- Add missing COPY instruction to include `/app/scripts` directory in the gatekey-server Docker image
- Install scripts were returning 404 errors because they weren't being copied into the container

## Test plan
- [x] Build and deploy gatekey-server image
- [x] Verify `curl -sSL https://gatekey.dye.tech/scripts/install-hub.sh` returns the script content
- [x] Verify `curl -sSL https://gatekey.dye.tech/scripts/install-gateway.sh` returns the script content