### PR TITLE
fix(gateway): resolve client connect timing issue and make names immutable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ web/.env.*.local
 Thumbs.db
 CLAUDE.md
 CLAUDE.md
+
+# Frontend build output
+web/dist/

--- a/cmd/gatekey-gateway/main.go
+++ b/cmd/gatekey-gateway/main.go
@@ -695,13 +695,9 @@ func handleHook(cmd *cobra.Command, args []string) error {
 		os.Exit(0)
 
 	case openvpn.HookClientConnect:
-		// Verify the client is actually connected by checking OpenVPN status file
-		// This prevents spurious connect events that OpenVPN sends during disconnect
-		time.Sleep(100 * time.Millisecond) // Brief delay to let status file update
-		if !isClientConnected(req.CommonName) {
-			fmt.Fprintf(os.Stderr, "Skipping connect notification - client %s not in status file\n", req.CommonName)
-			os.Exit(0)
-		}
+		// Note: We no longer check status file for client presence because OpenVPN
+		// updates the status file on a timer (default 10s), not immediately on connect.
+		// The control plane will validate the connection anyway.
 
 		resp, err := client.Connect(req)
 		if err != nil {
@@ -778,41 +774,6 @@ func writeClientFile(vpnIP string, client ConnectedClient) error {
 func removeClientFile(vpnIP string) {
 	filename := fmt.Sprintf("%s/%s.json", clientsDir, strings.ReplaceAll(vpnIP, ".", "-"))
 	os.Remove(filename)
-}
-
-// isClientConnected checks if a specific client (by common name) is in the OpenVPN status file
-func isClientConnected(commonName string) bool {
-	statusFile := "/var/log/openvpn/server-status.log"
-	data, err := os.ReadFile(statusFile)
-	if err != nil {
-		// Try alternate path
-		data, err = os.ReadFile("/var/log/openvpn/status.log")
-		if err != nil {
-			// If we can't read status file, assume connected to avoid blocking legitimate connections
-			return true
-		}
-	}
-
-	lines := strings.Split(string(data), "\n")
-	inClientList := false
-
-	for _, line := range lines {
-		if strings.HasPrefix(line, "ROUTING TABLE") {
-			inClientList = false
-		}
-		if strings.HasPrefix(line, "Common Name,") {
-			inClientList = true
-			continue
-		}
-		if inClientList && line != "" {
-			parts := strings.Split(line, ",")
-			if len(parts) >= 1 && parts[0] == commonName {
-				return true
-			}
-		}
-	}
-
-	return false
 }
 
 // loadConnectedClients loads all connected client files.

--- a/cmd/gatekey-hub/main.go
+++ b/cmd/gatekey-hub/main.go
@@ -934,37 +934,6 @@ func countConnections(prefix string) int {
 	return count
 }
 
-// isClientConnected checks if a specific client (by common name) is in the OpenVPN status file
-func isClientConnected(commonName string) bool {
-	statusFile := "/var/log/openvpn/hub-status.log"
-	data, err := os.ReadFile(statusFile)
-	if err != nil {
-		// If we can't read status file, assume connected to avoid blocking legitimate connections
-		return true
-	}
-
-	lines := strings.Split(string(data), "\n")
-	inClientList := false
-
-	for _, line := range lines {
-		if strings.HasPrefix(line, "ROUTING TABLE") {
-			inClientList = false
-		}
-		if strings.HasPrefix(line, "Common Name,") {
-			inClientList = true
-			continue
-		}
-		if inClientList && line != "" {
-			parts := strings.Split(line, ",")
-			if len(parts) >= 1 && parts[0] == commonName {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
 // ==================== Firewall Enforcement ====================
 
 // ConnectedClient represents a connected VPN client

--- a/internal/api/mesh_handlers.go
+++ b/internal/api/mesh_handlers.go
@@ -308,9 +308,11 @@ func (s *Server) handleUpdateMeshHub(c *gin.Context) {
 		return
 	}
 
-	// Update fields
-	if req.Name != "" {
-		hub.Name = req.Name
+	// Hub names are immutable because they are used for agent authentication.
+	// Changing the name would break the hub agent's connection to the control plane.
+	if req.Name != "" && req.Name != hub.Name {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "hub name cannot be changed after creation"})
+		return
 	}
 	if req.Description != "" {
 		hub.Description = req.Description
@@ -881,8 +883,11 @@ func (s *Server) handleUpdateMeshSpoke(c *gin.Context) {
 		return
 	}
 
-	if req.Name != "" {
-		gw.Name = req.Name
+	// Spoke names are immutable because they are used for agent authentication.
+	// Changing the name would break the spoke agent's connection to the control plane.
+	if req.Name != "" && req.Name != gw.Name {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "spoke name cannot be changed after creation"})
+		return
 	}
 	if req.Description != "" {
 		gw.Description = req.Description

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -3888,6 +3888,13 @@ func (s *Server) handleUpdateGateway(c *gin.Context) {
 		return
 	}
 
+	// Gateway names are immutable because they are used for agent authentication.
+	// Changing the name would break the gateway agent's connection to the control plane.
+	if req.Name != existingGw.Name {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "gateway name cannot be changed after creation"})
+		return
+	}
+
 	// Use existing TLSAuthEnabled if not specified in request
 	tlsAuthEnabled := existingGw.TLSAuthEnabled
 	if req.TLSAuthEnabled != nil {


### PR DESCRIPTION
## Summary
- Fixes gateway client-connect hook timing issue where connections were being skipped because OpenVPN updates status file on a 10s timer, not immediately on connect
- Makes gateway, mesh hub, and mesh spoke names immutable after creation to prevent authentication failures when renaming (agents authenticate using name+token)
- Removes unused `isClientConnected` function from both gateway and hub agents
- Adds `web/dist/` to `.gitignore`

## Root Causes Fixed
1. **Client connect timing issue**: The gateway hook checked if a client was in the OpenVPN status file before processing, but OpenVPN only updates this file on a timer (default 10s), causing legitimate connections to be skipped with "Skipping connect notification - client not in status file"

2. **Name immutability**: When a gateway/hub/spoke is renamed in the database, the agent config still has the old name, causing "Invalid token" authentication failures. Names are now immutable after creation for:
   - Gateways (OpenVPN and WireGuard)
   - Mesh Hubs
   - Mesh Spokes

## Test plan
- [x] Deploy updated server and verify it starts correctly
- [x] Verify gateway agent connects successfully
- [x] Verify VPN connectivity works (10.0.17.75:3306 reachable)
- [x] Test that attempting to rename a gateway via UI returns an error
- [x] Test that attempting to rename a mesh hub via UI returns an error
- [x] Test that attempting to rename a mesh spoke via UI returns an error