### PR TITLE
feat(ci): cascade releases to Helm chart and Homebrew repos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,4 +206,44 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           git diff --staged --quiet || git commit -m "Update formulas for GateKey v${{ steps.version.outputs.VERSION }}"
+          git tag -f "v${{ steps.version.outputs.VERSION }}"
           git push
+          git push origin "v${{ steps.version.outputs.VERSION }}" --force
+
+  update-helm-chart:
+    name: Update Helm Chart
+    needs: [release, docker, docker-web]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Checkout Helm Chart
+        uses: actions/checkout@v6
+        with:
+          repository: dye-tech/gatekey-helm-chart
+          path: helm-chart
+          ssh-key: ${{ secrets.HELM_CHART_DEPLOY_KEY }}
+
+      - name: Update Helm chart version
+        run: |
+          cd helm-chart
+
+          # Use same version for chart and app
+          sed -i "s/^version: .*/version: ${{ steps.version.outputs.VERSION }}/" Chart.yaml
+          sed -i "s/^appVersion: .*/appVersion: \"${{ steps.version.outputs.VERSION }}\"/" Chart.yaml
+
+          # Update all image tags in values.yaml
+          sed -i "s/tag: \"[0-9]*\.[0-9]*\.[0-9]*\"/tag: \"${{ steps.version.outputs.VERSION }}\"/g" values.yaml
+
+      - name: Push to Helm Chart repo
+        run: |
+          cd helm-chart
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --staged --quiet || git commit -m "chore: bump to v${{ steps.version.outputs.VERSION }}"
+          git tag -f "v${{ steps.version.outputs.VERSION }}"
+          git push
+          git push origin "v${{ steps.version.outputs.VERSION }}" --force


### PR DESCRIPTION
## Summary

Automates the release cascade process so that when a new version tag is pushed to GateKey, all related repos are updated with the **same version number**.

### What happens when you tag `v1.5.5`:

| Repository | Updates | Tag Created |
|------------|---------|-------------|
| **GateKey** | Release binaries & Docker images | `v1.5.5` |
| **homebrew-gatekey** | Formula files with new checksums | `v1.5.5` |
| **gatekey-helm-chart** | Chart.yaml version, appVersion, image tags | `v1.5.5` |

## Setup Required

Add a new repository secret:
- **`HELM_CHART_DEPLOY_KEY`**: SSH deploy key with write access to `dye-tech/gatekey-helm-chart`

To generate:
```bash
ssh-keygen -t ed25519 -C "gatekey-release-bot" -f helm-chart-deploy-key -N ""
```
- Add the public key as a deploy key in `gatekey-helm-chart` repo (with write access)
- Add the private key as a secret `HELM_CHART_DEPLOY_KEY` in this repo

## Flow

```
GateKey v1.5.5 tag pushed
        │
        ├──► Build binaries & Docker images
        │
        ├──► Update Homebrew formulas
        │    └──► Tag homebrew-gatekey v1.5.5
        │
        └──► Update Helm chart
             ├──► version: 1.5.5
             ├──► appVersion: "1.5.5"
             ├──► All image tags → 1.5.5
             └──► Tag gatekey-helm-chart v1.5.5
```