### PR TITLE
feat(gateway): add FIPS mode enforcement option

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -386,6 +386,7 @@ CREATE TABLE public.gateways (
     public_ip_v6 inet,
     internal_ip_v6 inet,
     vpn_subnet_v6 cidr,
+    enforce_fips_mode boolean DEFAULT false NOT NULL,
     CONSTRAINT chk_gateway_address CHECK (((hostname IS NOT NULL) OR (public_ip IS NOT NULL))),
     CONSTRAINT valid_gateway_type CHECK (((gateway_type)::text = ANY ((ARRAY['openvpn'::character varying, 'wireguard'::character varying])::text[])))
 );
@@ -669,6 +670,7 @@ CREATE TABLE public.mesh_gateways (
     wg_preshared_key text,
     local_networks_v6 text[] DEFAULT '{}'::text[] NOT NULL,
     tunnel_ip_v6 inet,
+    enforce_fips_mode boolean DEFAULT false NOT NULL,
     CONSTRAINT valid_mesh_spoke_gateway_type CHECK (((gateway_type)::text = ANY ((ARRAY['openvpn'::character varying, 'wireguard'::character varying])::text[])))
 );
 
@@ -785,6 +787,7 @@ CREATE TABLE public.mesh_hubs (
     wg_public_key text,
     wg_listen_port integer DEFAULT 51820,
     vpn_subnet_v6 cidr,
+    enforce_fips_mode boolean DEFAULT false NOT NULL,
     CONSTRAINT valid_mesh_hub_gateway_type CHECK (((gateway_type)::text = ANY ((ARRAY['openvpn'::character varying, 'wireguard'::character varying])::text[])))
 );
 

--- a/internal/api/mesh_handlers.go
+++ b/internal/api/mesh_handlers.go
@@ -65,6 +65,7 @@ func (s *Server) handleListMeshHubs(c *gin.Context) {
 			"pushDns":          hub.PushDNS,
 			"dnsServers":       hub.DNSServers,
 			"localNetworks":    hub.LocalNetworks,
+			"enforceFipsMode":  hub.EnforceFIPSMode,
 			"status":           status,
 			"statusMessage":    hub.StatusMessage,
 			"connectedSpokes":  hub.ConnectedSpokes,
@@ -95,8 +96,9 @@ func (s *Server) handleCreateMeshHub(c *gin.Context) {
 		VPNSubnetV6      string `json:"vpnSubnetV6"`
 		CryptoProfile    string `json:"cryptoProfile"`
 		TLSAuthEnabled   bool   `json:"tlsAuthEnabled"`
-		GatewayType      string `json:"gatewayType"`  // "openvpn" or "wireguard", default "openvpn"
-		WGListenPort     int    `json:"wgListenPort"` // WireGuard listen port, default 51820
+		GatewayType      string `json:"gatewayType"`     // "openvpn" or "wireguard", default "openvpn"
+		WGListenPort     int    `json:"wgListenPort"`    // WireGuard listen port, default 51820
+		EnforceFIPSMode  bool   `json:"enforceFipsMode"` // Enforce FIPS 140-3 mode at OS level
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -170,6 +172,7 @@ func (s *Server) handleCreateMeshHub(c *gin.Context) {
 		APIToken:        apiToken,
 		ControlPlaneURL: controlPlaneURL,
 		Status:          db.MeshHubStatusPending,
+		EnforceFIPSMode: req.EnforceFIPSMode,
 	}
 
 	// Generate WireGuard keypair if type is wireguard
@@ -210,6 +213,7 @@ func (s *Server) handleCreateMeshHub(c *gin.Context) {
 			"wgPublicKey":     hub.WGPublicKey,
 			"wgListenPort":    hub.WGListenPort,
 			"localNetworks":   hub.LocalNetworks,
+			"enforceFipsMode": hub.EnforceFIPSMode,
 			"apiToken":        apiToken, // Only shown once at creation
 			"controlPlaneUrl": controlPlaneURL,
 			"status":          hub.Status,
@@ -269,20 +273,21 @@ func (s *Server) handleUpdateMeshHub(c *gin.Context) {
 	hubID := c.Param("id")
 
 	var req struct {
-		Name           string   `json:"name"`
-		Description    string   `json:"description"`
-		PublicEndpoint string   `json:"publicEndpoint"`
-		VPNPort        int      `json:"vpnPort"`
-		VPNProtocol    string   `json:"vpnProtocol"`
-		VPNSubnet      string   `json:"vpnSubnet"`
-		CryptoProfile  string   `json:"cryptoProfile"`
-		TLSAuthEnabled *bool    `json:"tlsAuthEnabled"`
-		FullTunnelMode *bool    `json:"fullTunnelMode"`
-		PushDNS        *bool    `json:"pushDns"`
-		DNSServers     []string `json:"dnsServers"`
-		LocalNetworks  []string `json:"localNetworks"`
-		GatewayType    string   `json:"gatewayType"`  // Cannot be changed after creation
-		WGListenPort   int      `json:"wgListenPort"` // WireGuard listen port (only for wireguard type)
+		Name            string   `json:"name"`
+		Description     string   `json:"description"`
+		PublicEndpoint  string   `json:"publicEndpoint"`
+		VPNPort         int      `json:"vpnPort"`
+		VPNProtocol     string   `json:"vpnProtocol"`
+		VPNSubnet       string   `json:"vpnSubnet"`
+		CryptoProfile   string   `json:"cryptoProfile"`
+		TLSAuthEnabled  *bool    `json:"tlsAuthEnabled"`
+		FullTunnelMode  *bool    `json:"fullTunnelMode"`
+		PushDNS         *bool    `json:"pushDns"`
+		DNSServers      []string `json:"dnsServers"`
+		LocalNetworks   []string `json:"localNetworks"`
+		GatewayType     string   `json:"gatewayType"`     // Cannot be changed after creation
+		WGListenPort    int      `json:"wgListenPort"`    // WireGuard listen port (only for wireguard type)
+		EnforceFIPSMode *bool    `json:"enforceFipsMode"` // Enforce FIPS 140-3 mode at OS level
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -352,6 +357,9 @@ func (s *Server) handleUpdateMeshHub(c *gin.Context) {
 	// WireGuard listen port can only be updated for wireguard hubs
 	if req.WGListenPort > 0 && hub.GatewayType == db.MeshGatewayTypeWireGuard {
 		hub.WGListenPort = req.WGListenPort
+	}
+	if req.EnforceFIPSMode != nil {
+		hub.EnforceFIPSMode = *req.EnforceFIPSMode
 	}
 
 	if err := s.meshStore.UpdateHub(ctx, hub); err != nil {
@@ -448,10 +456,11 @@ func (s *Server) handleProvisionMeshHub(c *gin.Context) {
 	configVersion := computeConfigVersion(hub.VPNPort, hub.VPNProtocol, hub.VPNSubnet, hub.CryptoProfile, hub.TLSAuthEnabled, hub.TLSAuthKey, hub.CACert)
 
 	c.JSON(http.StatusOK, gin.H{
-		"message":       "hub provisioned successfully",
-		"configVersion": configVersion,
-		"hasCACert":     true,
-		"hasServerCert": true,
+		"message":         "hub provisioned successfully",
+		"configVersion":   configVersion,
+		"hasCACert":       true,
+		"hasServerCert":   true,
+		"enforceFipsMode": hub.EnforceFIPSMode,
 	})
 }
 
@@ -694,24 +703,25 @@ func (s *Server) handleListMeshSpokes(c *gin.Context) {
 		}
 
 		gwData := gin.H{
-			"id":             gw.ID,
-			"hubId":          gw.HubID,
-			"name":           gw.Name,
-			"description":    gw.Description,
-			"gatewayType":    gw.GatewayType,
-			"localNetworks":  gw.LocalNetworks,
-			"wgPublicKey":    gw.WGPublicKey,
-			"fullTunnelMode": gw.FullTunnelMode,
-			"pushDns":        gw.PushDNS,
-			"dnsServers":     gw.DNSServers,
-			"tunnelIp":       gw.TunnelIP,
-			"status":         status,
-			"statusMessage":  gw.StatusMessage,
-			"bytesSent":      gw.BytesSent,
-			"bytesReceived":  gw.BytesReceived,
-			"remoteIp":       gw.RemoteIP,
-			"createdAt":      gw.CreatedAt.Format(time.RFC3339),
-			"updatedAt":      gw.UpdatedAt.Format(time.RFC3339),
+			"id":              gw.ID,
+			"hubId":           gw.HubID,
+			"name":            gw.Name,
+			"description":     gw.Description,
+			"gatewayType":     gw.GatewayType,
+			"localNetworks":   gw.LocalNetworks,
+			"wgPublicKey":     gw.WGPublicKey,
+			"fullTunnelMode":  gw.FullTunnelMode,
+			"pushDns":         gw.PushDNS,
+			"dnsServers":      gw.DNSServers,
+			"tunnelIp":        gw.TunnelIP,
+			"enforceFipsMode": gw.EnforceFIPSMode,
+			"status":          status,
+			"statusMessage":   gw.StatusMessage,
+			"bytesSent":       gw.BytesSent,
+			"bytesReceived":   gw.BytesReceived,
+			"remoteIp":        gw.RemoteIP,
+			"createdAt":       gw.CreatedAt.Format(time.RFC3339),
+			"updatedAt":       gw.UpdatedAt.Format(time.RFC3339),
 		}
 		if gw.LastSeen != nil {
 			gwData["lastSeen"] = gw.LastSeen.Format(time.RFC3339)
@@ -758,13 +768,14 @@ func (s *Server) handleCreateMeshSpoke(c *gin.Context) {
 	}
 
 	gw := &db.MeshSpoke{
-		HubID:         hubID,
-		Name:          req.Name,
-		Description:   req.Description,
-		LocalNetworks: req.LocalNetworks,
-		Token:         token,
-		GatewayType:   hub.GatewayType, // Inherit from hub
-		Status:        db.MeshSpokeStatusPending,
+		HubID:           hubID,
+		Name:            req.Name,
+		Description:     req.Description,
+		LocalNetworks:   req.LocalNetworks,
+		Token:           token,
+		GatewayType:     hub.GatewayType,     // Inherit from hub
+		EnforceFIPSMode: hub.EnforceFIPSMode, // Inherit FIPS mode from hub
+		Status:          db.MeshSpokeStatusPending,
 	}
 
 	// Generate WireGuard keypair + PSK if hub type is wireguard
@@ -800,15 +811,16 @@ func (s *Server) handleCreateMeshSpoke(c *gin.Context) {
 
 	c.JSON(http.StatusCreated, gin.H{
 		"spoke": gin.H{
-			"id":            gw.ID,
-			"hubId":         gw.HubID,
-			"name":          gw.Name,
-			"description":   gw.Description,
-			"gatewayType":   gw.GatewayType,
-			"localNetworks": gw.LocalNetworks,
-			"wgPublicKey":   gw.WGPublicKey,
-			"token":         token, // Only shown once at creation
-			"status":        gw.Status,
+			"id":              gw.ID,
+			"hubId":           gw.HubID,
+			"name":            gw.Name,
+			"description":     gw.Description,
+			"gatewayType":     gw.GatewayType,
+			"localNetworks":   gw.LocalNetworks,
+			"wgPublicKey":     gw.WGPublicKey,
+			"enforceFipsMode": gw.EnforceFIPSMode,
+			"token":           token, // Only shown once at creation
+			"status":          gw.Status,
 		},
 		"message": "Spoke created. Use the install script to set up the spoke.",
 	})
@@ -831,25 +843,26 @@ func (s *Server) handleGetMeshSpoke(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"spoke": gin.H{
-			"id":             gw.ID,
-			"hubId":          gw.HubID,
-			"name":           gw.Name,
-			"description":    gw.Description,
-			"gatewayType":    gw.GatewayType,
-			"localNetworks":  gw.LocalNetworks,
-			"wgPublicKey":    gw.WGPublicKey,
-			"fullTunnelMode": gw.FullTunnelMode,
-			"pushDns":        gw.PushDNS,
-			"dnsServers":     gw.DNSServers,
-			"tunnelIp":       gw.TunnelIP,
-			"status":         gw.Status,
-			"statusMessage":  gw.StatusMessage,
-			"bytesSent":      gw.BytesSent,
-			"bytesReceived":  gw.BytesReceived,
-			"remoteIp":       gw.RemoteIP,
-			"hasClientCert":  gw.ClientCert != "",
-			"createdAt":      gw.CreatedAt.Format(time.RFC3339),
-			"updatedAt":      gw.UpdatedAt.Format(time.RFC3339),
+			"id":              gw.ID,
+			"hubId":           gw.HubID,
+			"name":            gw.Name,
+			"description":     gw.Description,
+			"gatewayType":     gw.GatewayType,
+			"localNetworks":   gw.LocalNetworks,
+			"wgPublicKey":     gw.WGPublicKey,
+			"fullTunnelMode":  gw.FullTunnelMode,
+			"pushDns":         gw.PushDNS,
+			"dnsServers":      gw.DNSServers,
+			"tunnelIp":        gw.TunnelIP,
+			"enforceFipsMode": gw.EnforceFIPSMode,
+			"status":          gw.Status,
+			"statusMessage":   gw.StatusMessage,
+			"bytesSent":       gw.BytesSent,
+			"bytesReceived":   gw.BytesReceived,
+			"remoteIp":        gw.RemoteIP,
+			"hasClientCert":   gw.ClientCert != "",
+			"createdAt":       gw.CreatedAt.Format(time.RFC3339),
+			"updatedAt":       gw.UpdatedAt.Format(time.RFC3339),
 		},
 	})
 }
@@ -985,9 +998,10 @@ func (s *Server) handleProvisionMeshSpoke(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"message":       "spoke provisioned successfully",
-		"tunnelIp":      tunnelIP,
-		"hasClientCert": true,
+		"message":         "spoke provisioned successfully",
+		"tunnelIp":        tunnelIP,
+		"hasClientCert":   true,
+		"enforceFipsMode": gw.EnforceFIPSMode,
 	})
 }
 

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -2967,18 +2967,19 @@ func (s *Server) handleGatewayProvision(c *gin.Context) {
 		zap.Bool("tls_auth_enabled", gateway.TLSAuthEnabled))
 
 	response := gin.H{
-		"gateway_id":       gateway.ID,
-		"gateway_name":     gateway.Name,
-		"ca_cert":          string(s.ca.CertificatePEM()),
-		"server_cert":      string(cert.CertificatePEM),
-		"server_key":       string(cert.PrivateKeyPEM),
-		"vpn_subnet":       vpnSubnet,
-		"vpn_network":      vpnNetwork,
-		"vpn_netmask":      vpnNetmask,
-		"vpn_port":         gateway.VPNPort,
-		"vpn_protocol":     gateway.VPNProtocol,
-		"crypto_profile":   gateway.CryptoProfile,
-		"tls_auth_enabled": gateway.TLSAuthEnabled,
+		"gateway_id":        gateway.ID,
+		"gateway_name":      gateway.Name,
+		"ca_cert":           string(s.ca.CertificatePEM()),
+		"server_cert":       string(cert.CertificatePEM),
+		"server_key":        string(cert.PrivateKeyPEM),
+		"vpn_subnet":        vpnSubnet,
+		"vpn_network":       vpnNetwork,
+		"vpn_netmask":       vpnNetmask,
+		"vpn_port":          gateway.VPNPort,
+		"vpn_protocol":      gateway.VPNProtocol,
+		"crypto_profile":    gateway.CryptoProfile,
+		"tls_auth_enabled":  gateway.TLSAuthEnabled,
+		"enforce_fips_mode": gateway.EnforceFIPSMode,
 	}
 
 	// Only include TLS-Auth key if enabled
@@ -3509,6 +3510,7 @@ func (s *Server) handleListGateways(c *gin.Context) {
 				gwData["wgPublicKey"] = gw.WGPublicKey
 			}
 		}
+		gwData["enforceFipsMode"] = gw.EnforceFIPSMode
 
 		if gw.LastHeartbeat != nil {
 			gwData["lastHeartbeat"] = gw.LastHeartbeat.Format(time.RFC3339)
@@ -3522,19 +3524,20 @@ func (s *Server) handleListGateways(c *gin.Context) {
 func (s *Server) handleRegisterGateway(c *gin.Context) {
 	// Register a new gateway (admin only)
 	var req struct {
-		Name           string   `json:"name" binding:"required"`
-		GatewayType    string   `json:"gateway_type"` // "openvpn" or "wireguard" (default: openvpn)
-		Hostname       string   `json:"hostname"`
-		PublicIP       string   `json:"public_ip"`
-		VPNPort        int      `json:"vpn_port"`
-		VPNProtocol    string   `json:"vpn_protocol"`
-		CryptoProfile  string   `json:"crypto_profile"`   // modern, fips, or compatible (OpenVPN only)
-		VPNSubnet      string   `json:"vpn_subnet"`       // VPN client subnet (e.g., "10.8.0.0/24")
-		TLSAuthEnabled *bool    `json:"tls_auth_enabled"` // Enable TLS-Auth (default: true, OpenVPN only)
-		FullTunnelMode *bool    `json:"full_tunnel_mode"` // Route all traffic through VPN (default: false)
-		PushDNS        *bool    `json:"push_dns"`         // Push DNS servers to clients (default: false)
-		DNSServers     []string `json:"dns_servers"`      // DNS server IPs to push
-		WGListenPort   int      `json:"wg_listen_port"`   // WireGuard listen port (default: 51820)
+		Name            string   `json:"name" binding:"required"`
+		GatewayType     string   `json:"gateway_type"` // "openvpn" or "wireguard" (default: openvpn)
+		Hostname        string   `json:"hostname"`
+		PublicIP        string   `json:"public_ip"`
+		VPNPort         int      `json:"vpn_port"`
+		VPNProtocol     string   `json:"vpn_protocol"`
+		CryptoProfile   string   `json:"crypto_profile"`    // modern, fips, or compatible (OpenVPN only)
+		VPNSubnet       string   `json:"vpn_subnet"`        // VPN client subnet (e.g., "10.8.0.0/24")
+		TLSAuthEnabled  *bool    `json:"tls_auth_enabled"`  // Enable TLS-Auth (default: true, OpenVPN only)
+		FullTunnelMode  *bool    `json:"full_tunnel_mode"`  // Route all traffic through VPN (default: false)
+		PushDNS         *bool    `json:"push_dns"`          // Push DNS servers to clients (default: false)
+		DNSServers      []string `json:"dns_servers"`       // DNS server IPs to push
+		WGListenPort    int      `json:"wg_listen_port"`    // WireGuard listen port (default: 51820)
+		EnforceFIPSMode *bool    `json:"enforce_fips_mode"` // Enforce FIPS 140-3 mode at OS level (default: false)
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -3638,21 +3641,28 @@ func (s *Server) handleRegisterGateway(c *gin.Context) {
 		pushDNS = *req.PushDNS
 	}
 
+	// Default Enforce FIPS Mode to false if not specified
+	enforceFIPSMode := false
+	if req.EnforceFIPSMode != nil {
+		enforceFIPSMode = *req.EnforceFIPSMode
+	}
+
 	gateway := &db.Gateway{
-		Name:           req.Name,
-		GatewayType:    gatewayType,
-		Hostname:       req.Hostname,
-		PublicIP:       req.PublicIP,
-		VPNPort:        req.VPNPort,
-		VPNProtocol:    req.VPNProtocol,
-		CryptoProfile:  req.CryptoProfile,
-		VPNSubnet:      req.VPNSubnet,
-		TLSAuthEnabled: tlsAuthEnabled,
-		FullTunnelMode: fullTunnelMode,
-		PushDNS:        pushDNS,
-		DNSServers:     req.DNSServers,
-		WGListenPort:   req.WGListenPort,
-		Token:          token,
+		Name:            req.Name,
+		GatewayType:     gatewayType,
+		Hostname:        req.Hostname,
+		PublicIP:        req.PublicIP,
+		VPNPort:         req.VPNPort,
+		VPNProtocol:     req.VPNProtocol,
+		CryptoProfile:   req.CryptoProfile,
+		VPNSubnet:       req.VPNSubnet,
+		TLSAuthEnabled:  tlsAuthEnabled,
+		FullTunnelMode:  fullTunnelMode,
+		PushDNS:         pushDNS,
+		DNSServers:      req.DNSServers,
+		WGListenPort:    req.WGListenPort,
+		EnforceFIPSMode: enforceFIPSMode,
+		Token:           token,
 	}
 
 	if err := s.gatewayStore.CreateGateway(ctx, gateway); err != nil {
@@ -3703,6 +3713,7 @@ func (s *Server) handleRegisterGateway(c *gin.Context) {
 			response["wgPublicKey"] = createdGateway.WGPublicKey
 		}
 	}
+	response["enforceFipsMode"] = createdGateway.EnforceFIPSMode
 
 	c.JSON(http.StatusCreated, response)
 }
@@ -3823,17 +3834,18 @@ func (s *Server) handleUpdateGateway(c *gin.Context) {
 	gatewayID := c.Param("id")
 
 	var req struct {
-		Name           string   `json:"name" binding:"required"`
-		Hostname       string   `json:"hostname"`
-		PublicIP       string   `json:"public_ip"`
-		VPNPort        int      `json:"vpn_port"`
-		VPNProtocol    string   `json:"vpn_protocol"`
-		CryptoProfile  string   `json:"crypto_profile"`   // modern, fips, or compatible
-		VPNSubnet      string   `json:"vpn_subnet"`       // VPN client subnet (e.g., "10.8.0.0/24")
-		TLSAuthEnabled *bool    `json:"tls_auth_enabled"` // Enable TLS-Auth
-		FullTunnelMode *bool    `json:"full_tunnel_mode"` // Route all traffic through VPN
-		PushDNS        *bool    `json:"push_dns"`         // Push DNS servers to clients
-		DNSServers     []string `json:"dns_servers"`      // DNS server IPs to push
+		Name            string   `json:"name" binding:"required"`
+		Hostname        string   `json:"hostname"`
+		PublicIP        string   `json:"public_ip"`
+		VPNPort         int      `json:"vpn_port"`
+		VPNProtocol     string   `json:"vpn_protocol"`
+		CryptoProfile   string   `json:"crypto_profile"`    // modern, fips, or compatible
+		VPNSubnet       string   `json:"vpn_subnet"`        // VPN client subnet (e.g., "10.8.0.0/24")
+		TLSAuthEnabled  *bool    `json:"tls_auth_enabled"`  // Enable TLS-Auth
+		FullTunnelMode  *bool    `json:"full_tunnel_mode"`  // Route all traffic through VPN
+		PushDNS         *bool    `json:"push_dns"`          // Push DNS servers to clients
+		DNSServers      []string `json:"dns_servers"`       // DNS server IPs to push
+		EnforceFIPSMode *bool    `json:"enforce_fips_mode"` // Enforce FIPS 140-3 mode at OS level
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -3919,19 +3931,26 @@ func (s *Server) handleUpdateGateway(c *gin.Context) {
 		dnsServers = req.DNSServers
 	}
 
+	// Use existing EnforceFIPSMode if not specified in request
+	enforceFIPSMode := existingGw.EnforceFIPSMode
+	if req.EnforceFIPSMode != nil {
+		enforceFIPSMode = *req.EnforceFIPSMode
+	}
+
 	gw := &db.Gateway{
-		ID:             gatewayID,
-		Name:           req.Name,
-		Hostname:       req.Hostname,
-		PublicIP:       req.PublicIP,
-		VPNPort:        req.VPNPort,
-		VPNProtocol:    req.VPNProtocol,
-		CryptoProfile:  req.CryptoProfile,
-		VPNSubnet:      req.VPNSubnet,
-		TLSAuthEnabled: tlsAuthEnabled,
-		FullTunnelMode: fullTunnelMode,
-		PushDNS:        pushDNS,
-		DNSServers:     dnsServers,
+		ID:              gatewayID,
+		Name:            req.Name,
+		Hostname:        req.Hostname,
+		PublicIP:        req.PublicIP,
+		VPNPort:         req.VPNPort,
+		VPNProtocol:     req.VPNProtocol,
+		CryptoProfile:   req.CryptoProfile,
+		VPNSubnet:       req.VPNSubnet,
+		TLSAuthEnabled:  tlsAuthEnabled,
+		FullTunnelMode:  fullTunnelMode,
+		PushDNS:         pushDNS,
+		DNSServers:      dnsServers,
+		EnforceFIPSMode: enforceFIPSMode,
 	}
 
 	if err := s.gatewayStore.UpdateGateway(ctx, gw); err != nil {

--- a/internal/db/gateways.go
+++ b/internal/db/gateways.go
@@ -20,23 +20,24 @@ var (
 
 // Gateway represents a registered VPN gateway
 type Gateway struct {
-	ID             string
-	Name           string
-	GatewayType    string // "openvpn" or "wireguard"
-	Hostname       string
-	PublicIP       string
-	PublicIPv6     *string // IPv6 public IP (optional)
-	VPNPort        int
-	VPNProtocol    string
-	CryptoProfile  string   // "modern", "fips", or "compatible" (OpenVPN only)
-	VPNSubnet      string   // VPN client subnet (e.g., "10.8.0.0/24")
-	VPNSubnetV6    *string  // IPv6 VPN client subnet (optional, e.g., "fd00::/64")
-	TLSAuthEnabled bool     // Enable TLS-Auth for additional security (OpenVPN only)
-	TLSAuthKey     string   // TLS-Auth static key (generated during provisioning) (OpenVPN only)
-	FullTunnelMode bool     // When true, route all traffic through VPN (push 0.0.0.0/0)
-	PushDNS        bool     // When true, push DNS servers to VPN clients
-	DNSServers     []string // DNS server IPs to push to clients
-	ConfigVersion  string   // Hash of config settings - changes trigger gateway reprovision
+	ID              string
+	Name            string
+	GatewayType     string // "openvpn" or "wireguard"
+	Hostname        string
+	PublicIP        string
+	PublicIPv6      *string // IPv6 public IP (optional)
+	VPNPort         int
+	VPNProtocol     string
+	CryptoProfile   string   // "modern", "fips", or "compatible" (OpenVPN only)
+	VPNSubnet       string   // VPN client subnet (e.g., "10.8.0.0/24")
+	VPNSubnetV6     *string  // IPv6 VPN client subnet (optional, e.g., "fd00::/64")
+	TLSAuthEnabled  bool     // Enable TLS-Auth for additional security (OpenVPN only)
+	TLSAuthKey      string   // TLS-Auth static key (generated during provisioning) (OpenVPN only)
+	FullTunnelMode  bool     // When true, route all traffic through VPN (push 0.0.0.0/0)
+	PushDNS         bool     // When true, push DNS servers to VPN clients
+	DNSServers      []string // DNS server IPs to push to clients
+	ConfigVersion   string   // Hash of config settings - changes trigger gateway reprovision
+	EnforceFIPSMode bool     // Enforce FIPS 140-3 mode at OS level
 	// WireGuard-specific fields
 	WGPrivateKey  string // WireGuard private key (WireGuard only)
 	WGPublicKey   string // WireGuard public key (WireGuard only)
@@ -121,9 +122,9 @@ func (s *GatewayStore) CreateGateway(ctx context.Context, gw *Gateway) error {
 	hashedToken := HashGatewayToken(gw.Token)
 	// Use NULLIF to convert empty string to NULL for hostname and inet type
 	_, err := s.db.Pool.Exec(ctx, `
-		INSERT INTO gateways (name, gateway_type, hostname, public_ip, public_ip_v6, vpn_port, vpn_protocol, crypto_profile, vpn_subnet, vpn_subnet_v6, tls_auth_enabled, full_tunnel_mode, push_dns, dns_servers, wg_private_key, wg_public_key, wg_listen_port, token, public_key)
-		VALUES ($1, $2, NULLIF($3, ''), NULLIF($4, '')::inet, NULLIF($5, '')::inet, $6, $7, $8, $9::cidr, $10::cidr, $11, $12, $13, $14, NULLIF($15, ''), NULLIF($16, ''), $17, $18, $19)
-	`, gw.Name, gatewayType, gw.Hostname, gw.PublicIP, gw.PublicIPv6, gw.VPNPort, gw.VPNProtocol, cryptoProfile, vpnSubnet, gw.VPNSubnetV6, gw.TLSAuthEnabled, gw.FullTunnelMode, gw.PushDNS, gw.DNSServers, gw.WGPrivateKey, gw.WGPublicKey, wgListenPort, hashedToken, gw.PublicKey)
+		INSERT INTO gateways (name, gateway_type, hostname, public_ip, public_ip_v6, vpn_port, vpn_protocol, crypto_profile, vpn_subnet, vpn_subnet_v6, tls_auth_enabled, full_tunnel_mode, push_dns, dns_servers, wg_private_key, wg_public_key, wg_listen_port, enforce_fips_mode, token, public_key)
+		VALUES ($1, $2, NULLIF($3, ''), NULLIF($4, '')::inet, NULLIF($5, '')::inet, $6, $7, $8, $9::cidr, $10::cidr, $11, $12, $13, $14, NULLIF($15, ''), NULLIF($16, ''), $17, $18, $19, $20)
+	`, gw.Name, gatewayType, gw.Hostname, gw.PublicIP, gw.PublicIPv6, gw.VPNPort, gw.VPNProtocol, cryptoProfile, vpnSubnet, gw.VPNSubnetV6, gw.TLSAuthEnabled, gw.FullTunnelMode, gw.PushDNS, gw.DNSServers, gw.WGPrivateKey, gw.WGPublicKey, wgListenPort, gw.EnforceFIPSMode, hashedToken, gw.PublicKey)
 	if err != nil && strings.Contains(err.Error(), "duplicate key") {
 		return ErrGatewayExists
 	}
@@ -136,9 +137,9 @@ func (s *GatewayStore) GetGateway(ctx context.Context, id string) (*Gateway, err
 	var hostname, publicIP, publicIPv6, vpnSubnet, vpnSubnetV6, tlsAuthKey, wgPrivateKey, wgPublicKey *string
 	var wgListenPort *int
 	err := s.db.Pool.QueryRow(ctx, `
-		SELECT id, name, COALESCE(gateway_type, 'openvpn'), hostname, host(public_ip), host(public_ip_v6), vpn_port, vpn_protocol, crypto_profile, vpn_subnet::text, vpn_subnet_v6::text, tls_auth_enabled, COALESCE(tls_auth_key, ''), full_tunnel_mode, push_dns, dns_servers, COALESCE(config_version, ''), wg_private_key, wg_public_key, wg_listen_port, token, public_key, is_active, last_heartbeat, created_at, updated_at
+		SELECT id, name, COALESCE(gateway_type, 'openvpn'), hostname, host(public_ip), host(public_ip_v6), vpn_port, vpn_protocol, crypto_profile, vpn_subnet::text, vpn_subnet_v6::text, tls_auth_enabled, COALESCE(tls_auth_key, ''), full_tunnel_mode, push_dns, dns_servers, COALESCE(config_version, ''), COALESCE(enforce_fips_mode, false), wg_private_key, wg_public_key, wg_listen_port, token, public_key, is_active, last_heartbeat, created_at, updated_at
 		FROM gateways WHERE id = $1
-	`, id).Scan(&gw.ID, &gw.Name, &gw.GatewayType, &hostname, &publicIP, &publicIPv6, &gw.VPNPort, &gw.VPNProtocol, &gw.CryptoProfile, &vpnSubnet, &vpnSubnetV6, &gw.TLSAuthEnabled, &gw.TLSAuthKey, &gw.FullTunnelMode, &gw.PushDNS, &gw.DNSServers, &gw.ConfigVersion, &wgPrivateKey, &wgPublicKey, &wgListenPort, &gw.Token, &gw.PublicKey, &gw.IsActive, &gw.LastHeartbeat, &gw.CreatedAt, &gw.UpdatedAt)
+	`, id).Scan(&gw.ID, &gw.Name, &gw.GatewayType, &hostname, &publicIP, &publicIPv6, &gw.VPNPort, &gw.VPNProtocol, &gw.CryptoProfile, &vpnSubnet, &vpnSubnetV6, &gw.TLSAuthEnabled, &gw.TLSAuthKey, &gw.FullTunnelMode, &gw.PushDNS, &gw.DNSServers, &gw.ConfigVersion, &gw.EnforceFIPSMode, &wgPrivateKey, &wgPublicKey, &wgListenPort, &gw.Token, &gw.PublicKey, &gw.IsActive, &gw.LastHeartbeat, &gw.CreatedAt, &gw.UpdatedAt)
 	if err == pgx.ErrNoRows {
 		return nil, ErrGatewayNotFound
 	}
@@ -179,9 +180,9 @@ func (s *GatewayStore) GetGatewayByName(ctx context.Context, name string) (*Gate
 	var hostname, publicIP, vpnSubnet, wgPrivateKey, wgPublicKey *string
 	var wgListenPort *int
 	err := s.db.Pool.QueryRow(ctx, `
-		SELECT id, name, COALESCE(gateway_type, 'openvpn'), hostname, host(public_ip), vpn_port, vpn_protocol, crypto_profile, vpn_subnet::text, tls_auth_enabled, COALESCE(tls_auth_key, ''), full_tunnel_mode, push_dns, dns_servers, COALESCE(config_version, ''), wg_private_key, wg_public_key, wg_listen_port, token, public_key, is_active, last_heartbeat, created_at, updated_at
+		SELECT id, name, COALESCE(gateway_type, 'openvpn'), hostname, host(public_ip), vpn_port, vpn_protocol, crypto_profile, vpn_subnet::text, tls_auth_enabled, COALESCE(tls_auth_key, ''), full_tunnel_mode, push_dns, dns_servers, COALESCE(config_version, ''), COALESCE(enforce_fips_mode, false), wg_private_key, wg_public_key, wg_listen_port, token, public_key, is_active, last_heartbeat, created_at, updated_at
 		FROM gateways WHERE name = $1
-	`, name).Scan(&gw.ID, &gw.Name, &gw.GatewayType, &hostname, &publicIP, &gw.VPNPort, &gw.VPNProtocol, &gw.CryptoProfile, &vpnSubnet, &gw.TLSAuthEnabled, &gw.TLSAuthKey, &gw.FullTunnelMode, &gw.PushDNS, &gw.DNSServers, &gw.ConfigVersion, &wgPrivateKey, &wgPublicKey, &wgListenPort, &gw.Token, &gw.PublicKey, &gw.IsActive, &gw.LastHeartbeat, &gw.CreatedAt, &gw.UpdatedAt)
+	`, name).Scan(&gw.ID, &gw.Name, &gw.GatewayType, &hostname, &publicIP, &gw.VPNPort, &gw.VPNProtocol, &gw.CryptoProfile, &vpnSubnet, &gw.TLSAuthEnabled, &gw.TLSAuthKey, &gw.FullTunnelMode, &gw.PushDNS, &gw.DNSServers, &gw.ConfigVersion, &gw.EnforceFIPSMode, &wgPrivateKey, &wgPublicKey, &wgListenPort, &gw.Token, &gw.PublicKey, &gw.IsActive, &gw.LastHeartbeat, &gw.CreatedAt, &gw.UpdatedAt)
 	if err == pgx.ErrNoRows {
 		return nil, ErrGatewayNotFound
 	}
@@ -222,9 +223,9 @@ func (s *GatewayStore) GetGatewayByToken(ctx context.Context, token string) (*Ga
 	// Hash the token to match against stored hash
 	hashedToken := HashGatewayToken(token)
 	err := s.db.Pool.QueryRow(ctx, `
-		SELECT id, name, COALESCE(gateway_type, 'openvpn'), hostname, host(public_ip), vpn_port, vpn_protocol, crypto_profile, vpn_subnet::text, tls_auth_enabled, COALESCE(tls_auth_key, ''), full_tunnel_mode, push_dns, dns_servers, COALESCE(config_version, ''), wg_private_key, wg_public_key, wg_listen_port, token, public_key, is_active, last_heartbeat, created_at, updated_at
+		SELECT id, name, COALESCE(gateway_type, 'openvpn'), hostname, host(public_ip), vpn_port, vpn_protocol, crypto_profile, vpn_subnet::text, tls_auth_enabled, COALESCE(tls_auth_key, ''), full_tunnel_mode, push_dns, dns_servers, COALESCE(config_version, ''), COALESCE(enforce_fips_mode, false), wg_private_key, wg_public_key, wg_listen_port, token, public_key, is_active, last_heartbeat, created_at, updated_at
 		FROM gateways WHERE token = $1
-	`, hashedToken).Scan(&gw.ID, &gw.Name, &gw.GatewayType, &hostname, &publicIP, &gw.VPNPort, &gw.VPNProtocol, &gw.CryptoProfile, &vpnSubnet, &gw.TLSAuthEnabled, &gw.TLSAuthKey, &gw.FullTunnelMode, &gw.PushDNS, &gw.DNSServers, &gw.ConfigVersion, &wgPrivateKey, &wgPublicKey, &wgListenPort, &gw.Token, &gw.PublicKey, &gw.IsActive, &gw.LastHeartbeat, &gw.CreatedAt, &gw.UpdatedAt)
+	`, hashedToken).Scan(&gw.ID, &gw.Name, &gw.GatewayType, &hostname, &publicIP, &gw.VPNPort, &gw.VPNProtocol, &gw.CryptoProfile, &vpnSubnet, &gw.TLSAuthEnabled, &gw.TLSAuthKey, &gw.FullTunnelMode, &gw.PushDNS, &gw.DNSServers, &gw.ConfigVersion, &gw.EnforceFIPSMode, &wgPrivateKey, &wgPublicKey, &wgListenPort, &gw.Token, &gw.PublicKey, &gw.IsActive, &gw.LastHeartbeat, &gw.CreatedAt, &gw.UpdatedAt)
 	if err == pgx.ErrNoRows {
 		return nil, ErrGatewayNotFound
 	}
@@ -275,7 +276,7 @@ func (s *GatewayStore) SetWireGuardKeys(ctx context.Context, gatewayID, privateK
 // ListGateways retrieves all gateways
 func (s *GatewayStore) ListGateways(ctx context.Context) ([]*Gateway, error) {
 	rows, err := s.db.Pool.Query(ctx, `
-		SELECT id, name, COALESCE(gateway_type, 'openvpn'), hostname, host(public_ip), vpn_port, vpn_protocol, crypto_profile, vpn_subnet::text, tls_auth_enabled, full_tunnel_mode, push_dns, dns_servers, wg_public_key, wg_listen_port, is_active, last_heartbeat, created_at, updated_at
+		SELECT id, name, COALESCE(gateway_type, 'openvpn'), hostname, host(public_ip), vpn_port, vpn_protocol, crypto_profile, vpn_subnet::text, tls_auth_enabled, full_tunnel_mode, push_dns, dns_servers, COALESCE(enforce_fips_mode, false), wg_public_key, wg_listen_port, is_active, last_heartbeat, created_at, updated_at
 		FROM gateways
 		ORDER BY name
 	`)
@@ -289,7 +290,7 @@ func (s *GatewayStore) ListGateways(ctx context.Context) ([]*Gateway, error) {
 		var gw Gateway
 		var hostname, publicIP, vpnSubnet, wgPublicKey *string
 		var wgListenPort *int
-		if err := rows.Scan(&gw.ID, &gw.Name, &gw.GatewayType, &hostname, &publicIP, &gw.VPNPort, &gw.VPNProtocol, &gw.CryptoProfile, &vpnSubnet, &gw.TLSAuthEnabled, &gw.FullTunnelMode, &gw.PushDNS, &gw.DNSServers, &wgPublicKey, &wgListenPort, &gw.IsActive, &gw.LastHeartbeat, &gw.CreatedAt, &gw.UpdatedAt); err != nil {
+		if err := rows.Scan(&gw.ID, &gw.Name, &gw.GatewayType, &hostname, &publicIP, &gw.VPNPort, &gw.VPNProtocol, &gw.CryptoProfile, &vpnSubnet, &gw.TLSAuthEnabled, &gw.FullTunnelMode, &gw.PushDNS, &gw.DNSServers, &gw.EnforceFIPSMode, &wgPublicKey, &wgListenPort, &gw.IsActive, &gw.LastHeartbeat, &gw.CreatedAt, &gw.UpdatedAt); err != nil {
 			return nil, err
 		}
 		if hostname != nil {
@@ -319,7 +320,7 @@ func (s *GatewayStore) ListGateways(ctx context.Context) ([]*Gateway, error) {
 // ListActiveGateways retrieves all active gateways
 func (s *GatewayStore) ListActiveGateways(ctx context.Context) ([]*Gateway, error) {
 	rows, err := s.db.Pool.Query(ctx, `
-		SELECT id, name, COALESCE(gateway_type, 'openvpn'), hostname, host(public_ip), vpn_port, vpn_protocol, crypto_profile, vpn_subnet::text, tls_auth_enabled, full_tunnel_mode, push_dns, dns_servers, wg_public_key, wg_listen_port, is_active, last_heartbeat, created_at, updated_at
+		SELECT id, name, COALESCE(gateway_type, 'openvpn'), hostname, host(public_ip), vpn_port, vpn_protocol, crypto_profile, vpn_subnet::text, tls_auth_enabled, full_tunnel_mode, push_dns, dns_servers, COALESCE(enforce_fips_mode, false), wg_public_key, wg_listen_port, is_active, last_heartbeat, created_at, updated_at
 		FROM gateways
 		WHERE is_active = true
 		ORDER BY name
@@ -334,7 +335,7 @@ func (s *GatewayStore) ListActiveGateways(ctx context.Context) ([]*Gateway, erro
 		var gw Gateway
 		var hostname, publicIP, vpnSubnet, wgPublicKey *string
 		var wgListenPort *int
-		if err := rows.Scan(&gw.ID, &gw.Name, &gw.GatewayType, &hostname, &publicIP, &gw.VPNPort, &gw.VPNProtocol, &gw.CryptoProfile, &vpnSubnet, &gw.TLSAuthEnabled, &gw.FullTunnelMode, &gw.PushDNS, &gw.DNSServers, &wgPublicKey, &wgListenPort, &gw.IsActive, &gw.LastHeartbeat, &gw.CreatedAt, &gw.UpdatedAt); err != nil {
+		if err := rows.Scan(&gw.ID, &gw.Name, &gw.GatewayType, &hostname, &publicIP, &gw.VPNPort, &gw.VPNProtocol, &gw.CryptoProfile, &vpnSubnet, &gw.TLSAuthEnabled, &gw.FullTunnelMode, &gw.PushDNS, &gw.DNSServers, &gw.EnforceFIPSMode, &wgPublicKey, &wgListenPort, &gw.IsActive, &gw.LastHeartbeat, &gw.CreatedAt, &gw.UpdatedAt); err != nil {
 			return nil, err
 		}
 		if hostname != nil {
@@ -435,9 +436,9 @@ func (s *GatewayStore) UpdateGateway(ctx context.Context, gw *Gateway) error {
 		SET name = $2, hostname = NULLIF($3, ''), public_ip = NULLIF($4, '')::inet, public_ip_v6 = NULLIF($5, '')::inet,
 		    vpn_port = $6, vpn_protocol = $7, crypto_profile = $8, vpn_subnet = $9::cidr, vpn_subnet_v6 = $10::cidr,
 		    tls_auth_enabled = $11, full_tunnel_mode = $12, push_dns = $13, dns_servers = $14,
-		    wg_listen_port = $15, updated_at = NOW()
+		    wg_listen_port = $15, enforce_fips_mode = $16, updated_at = NOW()
 		WHERE id = $1
-	`, gw.ID, gw.Name, gw.Hostname, gw.PublicIP, gw.PublicIPv6, gw.VPNPort, gw.VPNProtocol, cryptoProfile, vpnSubnet, gw.VPNSubnetV6, gw.TLSAuthEnabled, gw.FullTunnelMode, gw.PushDNS, gw.DNSServers, wgListenPort)
+	`, gw.ID, gw.Name, gw.Hostname, gw.PublicIP, gw.PublicIPv6, gw.VPNPort, gw.VPNProtocol, cryptoProfile, vpnSubnet, gw.VPNSubnetV6, gw.TLSAuthEnabled, gw.FullTunnelMode, gw.PushDNS, gw.DNSServers, wgListenPort, gw.EnforceFIPSMode)
 	if err != nil {
 		if strings.Contains(err.Error(), "duplicate key") {
 			return ErrGatewayExists

--- a/internal/db/mesh.go
+++ b/internal/db/mesh.go
@@ -97,6 +97,9 @@ type MeshHub struct {
 	// Config versioning
 	ConfigVersion string
 
+	// FIPS enforcement
+	EnforceFIPSMode bool // Enforce FIPS 140-3 mode at OS level
+
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
@@ -144,6 +147,9 @@ type MeshSpoke struct {
 
 	// Remote public IP when connected
 	RemoteIP string
+
+	// FIPS enforcement (inherited from hub, but can be stored for display)
+	EnforceFIPSMode bool // Enforce FIPS 140-3 mode at OS level
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
@@ -219,19 +225,19 @@ func (s *MeshStore) CreateHub(ctx context.Context, hub *MeshHub) error {
 			gateway_type, crypto_profile, tls_auth_enabled, tls_auth_key,
 			wg_private_key, wg_public_key, wg_listen_port,
 			ca_cert, ca_key, server_cert, server_key, dh_params,
-			api_token, control_plane_url, status, status_message
+			api_token, control_plane_url, status, status_message, enforce_fips_mode
 		) VALUES (
 			$1, $2, $3, $4, $5, $6::cidr, NULLIF($7, '')::cidr,
 			$8, $9, $10, $11,
 			$12, $13, $14,
 			$15, $16, $17, $18, $19,
-			$20, $21, $22, $23
+			$20, $21, $22, $23, $24
 		)
 	`, hub.Name, hub.Description, hub.PublicEndpoint, hub.VPNPort, hub.VPNProtocol, hub.VPNSubnet, hub.VPNSubnetV6,
 		hub.GatewayType, hub.CryptoProfile, hub.TLSAuthEnabled, hub.TLSAuthKey,
 		hub.WGPrivateKey, hub.WGPublicKey, hub.WGListenPort,
 		hub.CACert, hub.CAKey, hub.ServerCert, hub.ServerKey, hub.DHParams,
-		hub.APIToken, hub.ControlPlaneURL, hub.Status, hub.StatusMessage)
+		hub.APIToken, hub.ControlPlaneURL, hub.Status, hub.StatusMessage, hub.EnforceFIPSMode)
 
 	if err != nil && strings.Contains(err.Error(), "duplicate key") {
 		return ErrMeshHubExists
@@ -256,7 +262,7 @@ func (s *MeshStore) GetHub(ctx context.Context, id string) (*MeshHub, error) {
 			COALESCE(ca_cert, ''), COALESCE(ca_key, ''), COALESCE(server_cert, ''), COALESCE(server_key, ''), COALESCE(dh_params, ''),
 			api_token, control_plane_url,
 			status, COALESCE(status_message, ''), last_heartbeat, connected_gateways, connected_clients,
-			COALESCE(config_version, ''),
+			COALESCE(config_version, ''), COALESCE(enforce_fips_mode, false),
 			created_at, updated_at
 		FROM mesh_hubs WHERE id = $1
 	`, id).Scan(
@@ -270,7 +276,7 @@ func (s *MeshStore) GetHub(ctx context.Context, id string) (*MeshHub, error) {
 		&hub.CACert, &hub.CAKey, &hub.ServerCert, &hub.ServerKey, &hub.DHParams,
 		&hub.APIToken, &hub.ControlPlaneURL,
 		&hub.Status, &hub.StatusMessage, &hub.LastHeartbeat, &hub.ConnectedSpokes, &hub.ConnectedClients,
-		&hub.ConfigVersion,
+		&hub.ConfigVersion, &hub.EnforceFIPSMode,
 		&hub.CreatedAt, &hub.UpdatedAt,
 	)
 
@@ -309,7 +315,7 @@ func (s *MeshStore) GetHubByToken(ctx context.Context, token string) (*MeshHub, 
 			COALESCE(ca_cert, ''), COALESCE(ca_key, ''), COALESCE(server_cert, ''), COALESCE(server_key, ''), COALESCE(dh_params, ''),
 			api_token, control_plane_url,
 			status, COALESCE(status_message, ''), last_heartbeat, connected_gateways, connected_clients,
-			COALESCE(config_version, ''),
+			COALESCE(config_version, ''), COALESCE(enforce_fips_mode, false),
 			created_at, updated_at
 		FROM mesh_hubs WHERE api_token = $1
 	`, token).Scan(
@@ -323,7 +329,7 @@ func (s *MeshStore) GetHubByToken(ctx context.Context, token string) (*MeshHub, 
 		&hub.CACert, &hub.CAKey, &hub.ServerCert, &hub.ServerKey, &hub.DHParams,
 		&hub.APIToken, &hub.ControlPlaneURL,
 		&hub.Status, &hub.StatusMessage, &hub.LastHeartbeat, &hub.ConnectedSpokes, &hub.ConnectedClients,
-		&hub.ConfigVersion,
+		&hub.ConfigVersion, &hub.EnforceFIPSMode,
 		&hub.CreatedAt, &hub.UpdatedAt,
 	)
 
@@ -363,7 +369,7 @@ func (s *MeshStore) GetHubByName(name string) (*MeshHub, error) {
 			COALESCE(ca_cert, ''), COALESCE(ca_key, ''), COALESCE(server_cert, ''), COALESCE(server_key, ''), COALESCE(dh_params, ''),
 			api_token, control_plane_url,
 			status, COALESCE(status_message, ''), last_heartbeat, connected_gateways, connected_clients,
-			COALESCE(config_version, ''),
+			COALESCE(config_version, ''), COALESCE(enforce_fips_mode, false),
 			created_at, updated_at
 		FROM mesh_hubs WHERE name = $1
 	`, name).Scan(
@@ -377,7 +383,7 @@ func (s *MeshStore) GetHubByName(name string) (*MeshHub, error) {
 		&hub.CACert, &hub.CAKey, &hub.ServerCert, &hub.ServerKey, &hub.DHParams,
 		&hub.APIToken, &hub.ControlPlaneURL,
 		&hub.Status, &hub.StatusMessage, &hub.LastHeartbeat, &hub.ConnectedSpokes, &hub.ConnectedClients,
-		&hub.ConfigVersion,
+		&hub.ConfigVersion, &hub.EnforceFIPSMode,
 		&hub.CreatedAt, &hub.UpdatedAt,
 	)
 
@@ -410,6 +416,7 @@ func (s *MeshStore) ListHubs(ctx context.Context) ([]*MeshHub, error) {
 			COALESCE(full_tunnel_mode, false), COALESCE(push_dns, false), COALESCE(dns_servers, '{}'),
 			COALESCE(local_networks, '{}'),
 			status, COALESCE(status_message, ''), last_heartbeat, connected_gateways, connected_clients,
+			COALESCE(enforce_fips_mode, false),
 			created_at, updated_at
 		FROM mesh_hubs
 		ORDER BY name
@@ -434,6 +441,7 @@ func (s *MeshStore) ListHubs(ctx context.Context) ([]*MeshHub, error) {
 			&hub.FullTunnelMode, &hub.PushDNS, &hub.DNSServers,
 			&hub.LocalNetworks,
 			&hub.Status, &hub.StatusMessage, &hub.LastHeartbeat, &hub.ConnectedSpokes, &hub.ConnectedClients,
+			&hub.EnforceFIPSMode,
 			&hub.CreatedAt, &hub.UpdatedAt,
 		); err != nil {
 			return nil, err
@@ -461,13 +469,13 @@ func (s *MeshStore) UpdateHub(ctx context.Context, hub *MeshHub) error {
 			public_endpoint = $4, vpn_port = $5, vpn_protocol = $6, vpn_subnet = $7::cidr, vpn_subnet_v6 = NULLIF($8, '')::cidr,
 			crypto_profile = $9, tls_auth_enabled = $10, local_networks = $11,
 			wg_listen_port = $12,
-			full_tunnel_mode = $13, push_dns = $14, dns_servers = $15
+			full_tunnel_mode = $13, push_dns = $14, dns_servers = $15, enforce_fips_mode = $16
 		WHERE id = $1
 	`, hub.ID, hub.Name, hub.Description,
 		hub.PublicEndpoint, hub.VPNPort, hub.VPNProtocol, hub.VPNSubnet, hub.VPNSubnetV6,
 		hub.CryptoProfile, hub.TLSAuthEnabled, hub.LocalNetworks,
 		hub.WGListenPort,
-		hub.FullTunnelMode, hub.PushDNS, hub.DNSServers)
+		hub.FullTunnelMode, hub.PushDNS, hub.DNSServers, hub.EnforceFIPSMode)
 
 	if err != nil {
 		if strings.Contains(err.Error(), "duplicate key") {
@@ -579,21 +587,21 @@ func (s *MeshStore) CreateMeshSpoke(ctx context.Context, gw *MeshSpoke) error {
 			client_cert, client_key,
 			wg_private_key, wg_public_key, wg_preshared_key,
 			token,
-			status, status_message
+			status, status_message, enforce_fips_mode
 		) VALUES (
 			$1, $2, $3, $4,
 			$5,
 			$6, $7,
 			$8, $9, $10,
 			$11,
-			$12, $13
+			$12, $13, $14
 		)
 	`, gw.HubID, gw.Name, gw.Description, gw.LocalNetworks,
 		gw.GatewayType,
 		gw.ClientCert, gw.ClientKey,
 		gw.WGPrivateKey, gw.WGPublicKey, gw.WGPresharedKey,
 		gw.Token,
-		gw.Status, gw.StatusMessage)
+		gw.Status, gw.StatusMessage, gw.EnforceFIPSMode)
 
 	if err != nil && strings.Contains(err.Error(), "duplicate key") {
 		return ErrMeshSpokeExists
@@ -613,7 +621,7 @@ func (s *MeshStore) GetMeshSpoke(ctx context.Context, id string) (*MeshSpoke, er
 			COALESCE(wg_private_key, ''), COALESCE(wg_public_key, ''), COALESCE(wg_preshared_key, ''),
 			token,
 			status, COALESCE(status_message, ''), last_seen, bytes_sent, bytes_received,
-			host(remote_ip),
+			host(remote_ip), COALESCE(enforce_fips_mode, false),
 			created_at, updated_at
 		FROM mesh_gateways WHERE id = $1
 	`, id).Scan(
@@ -624,7 +632,7 @@ func (s *MeshStore) GetMeshSpoke(ctx context.Context, id string) (*MeshSpoke, er
 		&gw.WGPrivateKey, &gw.WGPublicKey, &gw.WGPresharedKey,
 		&gw.Token,
 		&gw.Status, &gw.StatusMessage, &gw.LastSeen, &gw.BytesSent, &gw.BytesReceived,
-		&remoteIP,
+		&remoteIP, &gw.EnforceFIPSMode,
 		&gw.CreatedAt, &gw.UpdatedAt,
 	)
 
@@ -656,7 +664,7 @@ func (s *MeshStore) GetMeshSpokeByToken(ctx context.Context, token string) (*Mes
 			COALESCE(wg_private_key, ''), COALESCE(wg_public_key, ''), COALESCE(wg_preshared_key, ''),
 			token,
 			status, COALESCE(status_message, ''), last_seen, bytes_sent, bytes_received,
-			host(remote_ip),
+			host(remote_ip), COALESCE(enforce_fips_mode, false),
 			created_at, updated_at
 		FROM mesh_gateways WHERE token = $1
 	`, token).Scan(
@@ -667,7 +675,7 @@ func (s *MeshStore) GetMeshSpokeByToken(ctx context.Context, token string) (*Mes
 		&gw.WGPrivateKey, &gw.WGPublicKey, &gw.WGPresharedKey,
 		&gw.Token,
 		&gw.Status, &gw.StatusMessage, &gw.LastSeen, &gw.BytesSent, &gw.BytesReceived,
-		&remoteIP,
+		&remoteIP, &gw.EnforceFIPSMode,
 		&gw.CreatedAt, &gw.UpdatedAt,
 	)
 
@@ -700,7 +708,7 @@ func (s *MeshStore) GetMeshSpokeByName(name string) (*MeshSpoke, error) {
 			COALESCE(wg_private_key, ''), COALESCE(wg_public_key, ''), COALESCE(wg_preshared_key, ''),
 			token,
 			status, COALESCE(status_message, ''), last_seen, bytes_sent, bytes_received,
-			host(remote_ip),
+			host(remote_ip), COALESCE(enforce_fips_mode, false),
 			created_at, updated_at
 		FROM mesh_gateways WHERE name = $1
 	`, name).Scan(
@@ -711,7 +719,7 @@ func (s *MeshStore) GetMeshSpokeByName(name string) (*MeshSpoke, error) {
 		&gw.WGPrivateKey, &gw.WGPublicKey, &gw.WGPresharedKey,
 		&gw.Token,
 		&gw.Status, &gw.StatusMessage, &gw.LastSeen, &gw.BytesSent, &gw.BytesReceived,
-		&remoteIP,
+		&remoteIP, &gw.EnforceFIPSMode,
 		&gw.CreatedAt, &gw.UpdatedAt,
 	)
 
@@ -739,7 +747,7 @@ func (s *MeshStore) ListMeshSpokesByHub(ctx context.Context, hubID string) ([]*M
 			COALESCE(full_tunnel_mode, false), COALESCE(push_dns, false), COALESCE(dns_servers, '{}'),
 			host(tunnel_ip), host(tunnel_ip_v6), COALESCE(wg_public_key, ''), COALESCE(wg_preshared_key, ''),
 			status, COALESCE(status_message, ''), last_seen,
-			bytes_sent, bytes_received, host(remote_ip),
+			bytes_sent, bytes_received, host(remote_ip), COALESCE(enforce_fips_mode, false),
 			created_at, updated_at
 		FROM mesh_gateways
 		WHERE hub_id = $1
@@ -760,7 +768,7 @@ func (s *MeshStore) ListMeshSpokesByHub(ctx context.Context, hubID string) ([]*M
 			&gw.FullTunnelMode, &gw.PushDNS, &gw.DNSServers,
 			&tunnelIP, &tunnelIPv6, &gw.WGPublicKey, &gw.WGPresharedKey,
 			&gw.Status, &gw.StatusMessage, &gw.LastSeen,
-			&gw.BytesSent, &gw.BytesReceived, &remoteIP,
+			&gw.BytesSent, &gw.BytesReceived, &remoteIP, &gw.EnforceFIPSMode,
 			&gw.CreatedAt, &gw.UpdatedAt,
 		); err != nil {
 			return nil, err
@@ -782,10 +790,10 @@ func (s *MeshStore) UpdateMeshSpoke(ctx context.Context, gw *MeshSpoke) error {
 	result, err := s.db.Pool.Exec(ctx, `
 		UPDATE mesh_gateways SET
 			name = $2, description = $3, local_networks = $4,
-			full_tunnel_mode = $5, push_dns = $6, dns_servers = $7
+			full_tunnel_mode = $5, push_dns = $6, dns_servers = $7, enforce_fips_mode = $8
 		WHERE id = $1
 	`, gw.ID, gw.Name, gw.Description, gw.LocalNetworks,
-		gw.FullTunnelMode, gw.PushDNS, gw.DNSServers)
+		gw.FullTunnelMode, gw.PushDNS, gw.DNSServers, gw.EnforceFIPSMode)
 
 	if err != nil {
 		if strings.Contains(err.Error(), "duplicate key") {

--- a/internal/db/migrations/000048_enforce_fips_mode.down.sql
+++ b/internal/db/migrations/000048_enforce_fips_mode.down.sql
@@ -1,0 +1,8 @@
+-- Remove enforce_fips_mode column from gateways table
+ALTER TABLE gateways DROP COLUMN IF EXISTS enforce_fips_mode;
+
+-- Remove enforce_fips_mode column from mesh_hubs table
+ALTER TABLE mesh_hubs DROP COLUMN IF EXISTS enforce_fips_mode;
+
+-- Remove enforce_fips_mode column from mesh_gateways (spokes) table
+ALTER TABLE mesh_gateways DROP COLUMN IF EXISTS enforce_fips_mode;

--- a/internal/db/migrations/000048_enforce_fips_mode.up.sql
+++ b/internal/db/migrations/000048_enforce_fips_mode.up.sql
@@ -1,0 +1,8 @@
+-- Add enforce_fips_mode column to gateways table
+ALTER TABLE gateways ADD COLUMN IF NOT EXISTS enforce_fips_mode BOOLEAN DEFAULT false NOT NULL;
+
+-- Add enforce_fips_mode column to mesh_hubs table
+ALTER TABLE mesh_hubs ADD COLUMN IF NOT EXISTS enforce_fips_mode BOOLEAN DEFAULT false NOT NULL;
+
+-- Add enforce_fips_mode column to mesh_gateways (spokes) table
+ALTER TABLE mesh_gateways ADD COLUMN IF NOT EXISTS enforce_fips_mode BOOLEAN DEFAULT false NOT NULL;

--- a/scripts/install-gateway.sh
+++ b/scripts/install-gateway.sh
@@ -30,6 +30,10 @@ OPENVPN_CONFIG_DIR="/etc/openvpn/server"
 VPN_PORT="1194"
 VPN_PROTOCOL="udp"
 VPN_NETWORK="172.31.255.0/24"
+ENABLE_FIPS="false"
+FIPS_REBOOT_REQUIRED=false
+FIPS_MANUAL_REQUIRED=false
+CRYPTO_PROFILE=""
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -58,6 +62,10 @@ while [[ $# -gt 0 ]]; do
             VPN_NETWORK="$2"
             shift 2
             ;;
+        --enable-fips)
+            ENABLE_FIPS="true"
+            shift
+            ;;
         --help)
             echo "GateKey Gateway Installer"
             echo ""
@@ -72,6 +80,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --port PORT       OpenVPN port (default: 1194)"
             echo "  --protocol PROTO  OpenVPN protocol: udp or tcp (default: udp)"
             echo "  --network CIDR    VPN network CIDR (default: 172.31.255.0/24)"
+            echo "  --enable-fips     Enable OS-level FIPS mode if FIPS crypto profile is used"
             echo ""
             exit 0
             ;;
@@ -119,6 +128,114 @@ detect_os() {
     else
         echo -e "${RED}Error: Unable to detect OS${NC}"
         exit 1
+    fi
+}
+
+# Check if FIPS mode is enabled at the OS level
+check_fips_mode() {
+    if [[ -f /proc/sys/crypto/fips_enabled ]]; then
+        FIPS_ENABLED=$(cat /proc/sys/crypto/fips_enabled)
+        if [[ "$FIPS_ENABLED" == "1" ]]; then
+            return 0  # FIPS enabled
+        fi
+    fi
+    return 1  # FIPS not enabled
+}
+
+# Setup FIPS mode on the system
+setup_fips_mode() {
+    echo -e "${YELLOW}Setting up FIPS mode...${NC}"
+
+    case $OS in
+        rhel|centos|rocky|almalinux|fedora)
+            # Check if fips-mode-setup is available
+            if command -v fips-mode-setup &> /dev/null; then
+                echo -e "${YELLOW}Enabling FIPS mode (system will require reboot)...${NC}"
+                fips-mode-setup --enable
+                FIPS_REBOOT_REQUIRED=true
+            else
+                echo -e "${RED}Error: fips-mode-setup not found. Install with: dnf install crypto-policies-scripts${NC}"
+                echo -e "${YELLOW}Installing crypto-policies-scripts...${NC}"
+                dnf install -y crypto-policies-scripts
+                fips-mode-setup --enable
+                FIPS_REBOOT_REQUIRED=true
+            fi
+            ;;
+        ubuntu|debian)
+            echo -e "${YELLOW}FIPS mode on Ubuntu/Debian requires Ubuntu Pro subscription.${NC}"
+            echo -e "${YELLOW}Please enable FIPS manually:${NC}"
+            echo "  1. Attach Ubuntu Pro: sudo pro attach <token>"
+            echo "  2. Enable FIPS: sudo pro enable fips"
+            echo "  3. Reboot the system"
+            echo ""
+            echo -e "${RED}Continuing without FIPS mode. For true FIPS compliance, enable FIPS manually.${NC}"
+            FIPS_MANUAL_REQUIRED=true
+            ;;
+        amzn)
+            if [[ "$VERSION" == "2023" ]] || [[ "$VERSION" =~ ^2023 ]]; then
+                echo -e "${YELLOW}Amazon Linux 2023 FIPS mode:${NC}"
+                if command -v fips-mode-setup &> /dev/null; then
+                    fips-mode-setup --enable
+                    FIPS_REBOOT_REQUIRED=true
+                else
+                    echo -e "${RED}FIPS mode setup not available on this Amazon Linux version${NC}"
+                    FIPS_MANUAL_REQUIRED=true
+                fi
+            else
+                echo -e "${RED}FIPS mode not supported on Amazon Linux 2${NC}"
+                FIPS_MANUAL_REQUIRED=true
+            fi
+            ;;
+        *)
+            echo -e "${RED}FIPS mode setup not supported for $OS${NC}"
+            echo -e "${YELLOW}Please enable FIPS mode manually according to your OS documentation.${NC}"
+            FIPS_MANUAL_REQUIRED=true
+            ;;
+    esac
+}
+
+# Handle FIPS crypto profile requirements
+handle_fips_profile() {
+    local crypto_profile="$1"
+
+    if [[ "$crypto_profile" != "fips" ]]; then
+        return 0  # Not FIPS profile, nothing to do
+    fi
+
+    echo -e "${YELLOW}FIPS crypto profile detected${NC}"
+
+    if check_fips_mode; then
+        echo -e "${GREEN}OS FIPS mode is already enabled${NC}"
+        return 0
+    fi
+
+    echo -e "${YELLOW}WARNING: FIPS crypto profile requires OS-level FIPS mode for true compliance${NC}"
+    echo ""
+    echo "GateKey's FIPS profile uses FIPS-approved algorithms, but true FIPS 140-2/140-3"
+    echo "compliance requires the operating system to be running in FIPS mode with"
+    echo "NIST-validated cryptographic modules."
+    echo ""
+
+    # Check if --enable-fips flag was passed
+    if [[ "$ENABLE_FIPS" == "true" ]]; then
+        setup_fips_mode
+    else
+        echo -e "${YELLOW}To enable OS FIPS mode, re-run this script with --enable-fips${NC}"
+        echo "Or enable FIPS mode manually:"
+        case $OS in
+            rhel|centos|rocky|almalinux|fedora)
+                echo "  sudo fips-mode-setup --enable"
+                echo "  sudo reboot"
+                ;;
+            ubuntu|debian)
+                echo "  sudo pro enable fips  (requires Ubuntu Pro)"
+                echo "  sudo reboot"
+                ;;
+            *)
+                echo "  Consult your OS documentation for FIPS mode setup"
+                ;;
+        esac
+        echo ""
     fi
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -150,6 +150,8 @@ export interface AdminGateway {
   // WireGuard-specific fields
   wgPublicKey?: string
   wgListenPort?: number
+  // FIPS enforcement
+  enforceFipsMode: boolean
 }
 
 export interface RegisterGatewayRequest {
@@ -171,6 +173,8 @@ export interface RegisterGatewayRequest {
   gateway_type?: GatewayType
   // WireGuard-specific fields
   wg_listen_port?: number
+  // FIPS enforcement
+  enforce_fips_mode?: boolean
 }
 
 export interface RegisterGatewayResponse {
@@ -234,6 +238,7 @@ export interface UpdateGatewayRequest {
   push_dns?: boolean
   dns_servers?: string[]
   session_enabled?: boolean
+  enforce_fips_mode?: boolean
 }
 
 export async function updateGateway(id: string, req: UpdateGatewayRequest): Promise<void> {
@@ -1308,6 +1313,7 @@ export interface MeshHub {
   pushDns: boolean
   dnsServers: string[]
   localNetworks: string[]
+  enforceFipsMode: boolean
   sessionEnabled: boolean
   status: MeshHubStatus
   statusMessage: string
@@ -1340,6 +1346,7 @@ export interface CreateMeshHubRequest {
   pushDns?: boolean
   dnsServers?: string[]
   localNetworks?: string[]
+  enforceFipsMode?: boolean
   sessionEnabled?: boolean
 }
 
@@ -1354,6 +1361,7 @@ export interface MeshSpoke {
   fullTunnelMode: boolean
   pushDns: boolean
   dnsServers: string[]
+  enforceFipsMode: boolean
   sessionEnabled: boolean
   tunnelIp: string
   tunnelIpV6?: string
@@ -1400,6 +1408,7 @@ export async function getMeshHubs(): Promise<MeshHub[]> {
     pushDns: hub.pushDns || false,
     dnsServers: (hub.dnsServers as string[]) || [],
     localNetworks: (hub.localNetworks as string[]) || [],
+    enforceFipsMode: hub.enforceFipsMode || false,
     sessionEnabled: hub.sessionEnabled ?? true,
     status: hub.status,
     statusMessage: hub.statusMessage || '',
@@ -1432,6 +1441,7 @@ export async function getMeshHub(id: string): Promise<MeshHub> {
     pushDns: hub.pushDns || false,
     dnsServers: hub.dnsServers || [],
     localNetworks: hub.localNetworks || [],
+    enforceFipsMode: hub.enforceFipsMode || false,
     sessionEnabled: hub.sessionEnabled ?? true,
     status: hub.status,
     statusMessage: hub.statusMessage || '',
@@ -1464,6 +1474,7 @@ export async function createMeshHub(req: CreateMeshHubRequest): Promise<MeshHubW
     pushDns: hub.pushDns || false,
     dnsServers: hub.dnsServers || [],
     localNetworks: hub.localNetworks || [],
+    enforceFipsMode: hub.enforceFipsMode || false,
     sessionEnabled: hub.sessionEnabled ?? true,
     apiToken: hub.apiToken,
     controlPlaneUrl: hub.controlPlaneUrl,
@@ -1563,6 +1574,7 @@ export async function getMeshSpokes(hubId: string): Promise<MeshSpoke[]> {
     fullTunnelMode: spoke.fullTunnelMode || false,
     pushDns: spoke.pushDns || false,
     dnsServers: (spoke.dnsServers as string[]) || [],
+    enforceFipsMode: spoke.enforceFipsMode || false,
     sessionEnabled: spoke.sessionEnabled ?? true,
     tunnelIp: spoke.tunnelIp || '',
     tunnelIpV6: spoke.tunnelIpV6 as string | undefined,
@@ -1592,6 +1604,7 @@ export async function getMeshSpoke(id: string): Promise<MeshSpoke> {
     fullTunnelMode: spoke.fullTunnelMode || false,
     pushDns: spoke.pushDns || false,
     dnsServers: spoke.dnsServers || [],
+    enforceFipsMode: spoke.enforceFipsMode || false,
     sessionEnabled: spoke.sessionEnabled ?? true,
     tunnelIp: spoke.tunnelIp || '',
     tunnelIpV6: spoke.tunnelIpV6,
@@ -1621,6 +1634,7 @@ export async function createMeshSpoke(hubId: string, req: CreateMeshSpokeRequest
     fullTunnelMode: spoke.fullTunnelMode || false,
     pushDns: spoke.pushDns || false,
     dnsServers: spoke.dnsServers || [],
+    enforceFipsMode: spoke.enforceFipsMode || false,
     sessionEnabled: spoke.sessionEnabled ?? true,
     tunnelIp: '',
     tunnelIpV6: spoke.tunnelIpV6,

--- a/web/src/pages/AdminGateways.tsx
+++ b/web/src/pages/AdminGateways.tsx
@@ -289,6 +289,7 @@ export default function AdminGateways() {
               pushDns: false, // Default for new gateways
               dnsServers: [], // Default for new gateways
               sessionEnabled: true, // Default for new gateways
+              enforceFipsMode: false, // Default for new gateways
               gatewayType: newGateway.gatewayType || 'openvpn',
               wgPublicKey: newGateway.wgPublicKey,
               wgListenPort: newGateway.wgListenPort,
@@ -374,6 +375,7 @@ function AddGatewayModal({ onClose, onSuccess }: AddGatewayModalProps) {
   const [pushDns, setPushDns] = useState(false)
   const [dnsServers, setDnsServers] = useState('1.1.1.1, 8.8.8.8')
   const [sessionEnabled, setSessionEnabled] = useState(true)
+  const [enforceFipsMode, setEnforceFipsMode] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [allowedCryptoProfiles, setAllowedCryptoProfiles] = useState<string[]>([])
@@ -429,6 +431,7 @@ function AddGatewayModal({ onClose, onSuccess }: AddGatewayModalProps) {
         push_dns: pushDns,
         dns_servers: pushDns ? dnsServers.split(',').map(s => s.trim()).filter(s => s) : [],
         session_enabled: sessionEnabled,
+        enforce_fips_mode: enforceFipsMode,
         gateway_type: gatewayType,
         wg_listen_port: gatewayType === 'wireguard' ? parseInt(vpnPort) || 51820 : undefined,
       })
@@ -757,6 +760,22 @@ function AddGatewayModal({ onClose, onSuccess }: AddGatewayModalProps) {
             Allow administrators to run commands on this gateway via the Remote Sessions page.
           </p>
 
+          <div className="flex items-center">
+            <input
+              type="checkbox"
+              id="enforceFipsMode"
+              checked={enforceFipsMode}
+              onChange={(e) => setEnforceFipsMode(e.target.checked)}
+              className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-theme rounded"
+            />
+            <label htmlFor="enforceFipsMode" className="ml-2 block text-sm text-theme-secondary">
+              Enforce FIPS Mode
+            </label>
+          </div>
+          <p className="text-xs text-theme-tertiary -mt-2">
+            Enforce FIPS 140-3 cryptographic mode at the OS level. Requires FIPS-enabled operating system.
+          </p>
+
           <div className="flex justify-end space-x-3 pt-4">
             <button
               type="button"
@@ -1026,6 +1045,7 @@ function EditGatewayModal({ gateway, onClose, onSuccess }: EditGatewayModalProps
   const [pushDns, setPushDns] = useState(gateway.pushDns ?? false)
   const [dnsServers, setDnsServers] = useState((gateway.dnsServers ?? []).join(', ') || '1.1.1.1, 8.8.8.8')
   const [sessionEnabled, setSessionEnabled] = useState(gateway.sessionEnabled ?? true)
+  const [enforceFipsMode, setEnforceFipsMode] = useState(gateway.enforceFipsMode ?? false)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -1059,6 +1079,7 @@ function EditGatewayModal({ gateway, onClose, onSuccess }: EditGatewayModalProps
         push_dns: pushDns,
         dns_servers: pushDns ? dnsServers.split(',').map(s => s.trim()).filter(s => s) : [],
         session_enabled: sessionEnabled,
+        enforce_fips_mode: enforceFipsMode,
       })
       onSuccess()
     } catch (err: unknown) {
@@ -1325,6 +1346,22 @@ function EditGatewayModal({ gateway, onClose, onSuccess }: EditGatewayModalProps
           </div>
           <p className="text-xs text-theme-tertiary -mt-2">
             Allow administrators to run commands on this gateway via the Remote Sessions page.
+          </p>
+
+          <div className="flex items-center">
+            <input
+              type="checkbox"
+              id="editEnforceFipsMode"
+              checked={enforceFipsMode}
+              onChange={(e) => setEnforceFipsMode(e.target.checked)}
+              className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-theme rounded"
+            />
+            <label htmlFor="editEnforceFipsMode" className="ml-2 block text-sm text-theme-secondary">
+              Enforce FIPS Mode
+            </label>
+          </div>
+          <p className="text-xs text-theme-tertiary -mt-2">
+            Enforce FIPS 140-3 cryptographic mode at the OS level. Requires FIPS-enabled operating system.
           </p>
 
           <div className="flex justify-end space-x-3 pt-4">

--- a/web/src/pages/AdminMesh.tsx
+++ b/web/src/pages/AdminMesh.tsx
@@ -634,6 +634,7 @@ function AddHubModal({ onClose, onSuccess }: { onClose: () => void; onSuccess: (
     fullTunnelMode: false,
     pushDns: false,
     dnsServers: [],
+    enforceFipsMode: false,
     sessionEnabled: true,
   })
   const [dnsInput, setDnsInput] = useState('')
@@ -1028,6 +1029,22 @@ function AddHubModal({ onClose, onSuccess }: { onClose: () => void; onSuccess: (
             </div>
             <p className="text-xs text-theme-tertiary -mt-2">
               Allow administrators to run commands on this hub via the Remote Sessions page.
+            </p>
+
+            <div className="flex items-center">
+              <input
+                type="checkbox"
+                id="hubEnforceFipsMode"
+                checked={form.enforceFipsMode ?? false}
+                onChange={(e) => setForm({ ...form, enforceFipsMode: e.target.checked })}
+                className="rounded border-theme text-primary-600 focus:ring-primary-500"
+              />
+              <label htmlFor="hubEnforceFipsMode" className="ml-2 text-sm text-theme-secondary">
+                Enforce FIPS Mode
+              </label>
+            </div>
+            <p className="text-xs text-theme-tertiary -mt-2">
+              Enforce FIPS 140-3 cryptographic mode at the OS level. Requires FIPS-enabled operating system.
             </p>
 
             <div className="flex justify-end space-x-3 pt-4">
@@ -2159,7 +2176,7 @@ function ManageSpokeAccessModal({ spoke, onClose }: { spoke: MeshSpoke; onClose:
 
 // Edit Hub Modal Component
 function EditHubModal({ hub, onClose, onSuccess }: { hub: MeshHub; onClose: () => void; onSuccess: () => void }) {
-  const [form, setForm] = useState({ name: hub.name, description: hub.description || '', publicEndpoint: hub.publicEndpoint || '', vpnPort: hub.vpnPort || 1194, vpnProtocol: hub.vpnProtocol || 'udp', vpnSubnet: hub.vpnSubnet || '172.30.0.0/16', vpnSubnetV6: hub.vpnSubnetV6 || '', cryptoProfile: hub.cryptoProfile || 'modern' as CryptoProfile, tlsAuthEnabled: hub.tlsAuthEnabled ?? true, fullTunnelMode: hub.fullTunnelMode ?? false, pushDns: hub.pushDns ?? false, dnsServers: hub.dnsServers || [], localNetworks: hub.localNetworks || [], sessionEnabled: hub.sessionEnabled ?? true })
+  const [form, setForm] = useState({ name: hub.name, description: hub.description || '', publicEndpoint: hub.publicEndpoint || '', vpnPort: hub.vpnPort || 1194, vpnProtocol: hub.vpnProtocol || 'udp', vpnSubnet: hub.vpnSubnet || '172.30.0.0/16', vpnSubnetV6: hub.vpnSubnetV6 || '', cryptoProfile: hub.cryptoProfile || 'modern' as CryptoProfile, tlsAuthEnabled: hub.tlsAuthEnabled ?? true, fullTunnelMode: hub.fullTunnelMode ?? false, pushDns: hub.pushDns ?? false, dnsServers: hub.dnsServers || [], localNetworks: hub.localNetworks || [], enforceFipsMode: hub.enforceFipsMode ?? false, sessionEnabled: hub.sessionEnabled ?? true })
   const [dnsInput, setDnsInput] = useState('')
   const [networkInput, setNetworkInput] = useState('')
   const [loading, setLoading] = useState(false)
@@ -2222,6 +2239,8 @@ function EditHubModal({ hub, onClose, onSuccess }: { hub: MeshHub; onClose: () =
             <div><label className="block text-sm font-medium text-theme-secondary">Local Networks</label><div className="flex space-x-2"><input type="text" value={networkInput} onChange={(e) => setNetworkInput(e.target.value)} className="input flex-1" placeholder="192.168.1.0/24" onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); if (networkInput) { setForm({ ...form, localNetworks: [...form.localNetworks, networkInput] }); setNetworkInput('') } } }} /><button type="button" onClick={() => { if (networkInput) { setForm({ ...form, localNetworks: [...form.localNetworks, networkInput] }); setNetworkInput('') } }} className="btn btn-secondary">Add</button></div>{form.localNetworks.length > 0 && <div className="flex flex-wrap gap-2 mt-2">{form.localNetworks.map((n) => <span key={n} className="px-2 py-1 bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-200 rounded text-sm font-medium">{n}<button type="button" onClick={() => setForm({ ...form, localNetworks: form.localNetworks.filter(x => x !== n) })} className="ml-1 text-red-500 hover:text-red-600">×</button></span>)}</div>}</div>
             <div className="flex items-center"><input type="checkbox" id="editHubSessionEnabled" checked={form.sessionEnabled ?? true} onChange={(e) => setForm({ ...form, sessionEnabled: e.target.checked })} className="rounded border-theme text-primary-600 focus:ring-primary-500" /><label htmlFor="editHubSessionEnabled" className="ml-2 text-sm text-theme-secondary">Enable Remote Sessions</label></div>
             <p className="text-xs text-theme-tertiary -mt-2">Allow administrators to run commands on this hub via the Remote Sessions page.</p>
+            <div className="flex items-center"><input type="checkbox" id="editHubEnforceFipsMode" checked={form.enforceFipsMode ?? false} onChange={(e) => setForm({ ...form, enforceFipsMode: e.target.checked })} className="rounded border-theme text-primary-600 focus:ring-primary-500" /><label htmlFor="editHubEnforceFipsMode" className="ml-2 text-sm text-theme-secondary">Enforce FIPS Mode</label></div>
+            <p className="text-xs text-theme-tertiary -mt-2">Enforce FIPS 140-3 cryptographic mode at the OS level. Requires FIPS-enabled operating system.</p>
             <div className="flex justify-end space-x-3 pt-4"><button type="button" onClick={onClose} className="btn btn-secondary">Cancel</button><button type="submit" disabled={loading} className="btn btn-primary">{loading ? 'Saving...' : 'Save'}</button></div>
           </form>
         </div>


### PR DESCRIPTION
## Summary
- Add `enforce_fips_mode` boolean field to gateways, mesh hubs, and mesh spokes for FIPS 140-3 cryptographic compliance
- Include database migration (000048) adding the column to all three tables with a default of `false`
- Mesh spokes automatically inherit FIPS mode setting from their parent hub

## Changes
- **Database**: Schema and migration for `enforce_fips_mode` column on gateways, mesh_hubs, and mesh_gateways tables
- **Backend**: Go model updates, CRUD operations, and API handlers for all affected entities
- **Frontend**: TypeScript interfaces, API client mappings, and UI checkboxes in admin forms

## Test plan
- [ ] Verify database migration applies cleanly (up and down)
- [ ] Create a gateway with FIPS mode enabled and verify it persists
- [ ] Create a mesh hub with FIPS mode enabled and verify spokes inherit the setting
- [ ] Verify the checkbox appears and functions in gateway and mesh hub admin forms
- [ ] Confirm the setting is returned in provisioning API responses