### PR TITLE
build(docker): update Node.js to 25-alpine for web build

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,5 +1,5 @@
 # Build frontend
-FROM node:20-alpine AS builder
+FROM node:25-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Update Node.js builder image from `node:20-alpine` to `node:25-alpine` in Dockerfile.web
- Node.js 25 provides latest features and performance improvements

## Test plan
- [x] Built gatekey-web image successfully with Node.js 25
- [x] Pushed to Harbor (`harbor.dye.tech/library/gatekey-web:node25-test`)
- [x] Deployed test pod to Kubernetes
- [x] Verified web assets built correctly (vite build completed)
- [x] Confirmed Alpine 3.23.2 and nginx 1.29.4 in final image