### PR TITLE
feat: add custom error types for consistent API error responses

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,332 @@
+// Package errors provides structured error types for the GateKey application.
+// It defines error codes that clients can use to handle errors programmatically,
+// and provides a consistent error response format across all API endpoints.
+package errors
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Error codes for client consumption.
+// These codes are stable and can be relied upon for programmatic error handling.
+const (
+	// Authentication errors (AUTH_*)
+	CodeInvalidCredentials  = "AUTH_INVALID_CREDENTIALS"
+	CodeSessionExpired      = "AUTH_SESSION_EXPIRED"
+	CodeSessionNotFound     = "AUTH_SESSION_NOT_FOUND"
+	CodeTokenInvalid        = "AUTH_TOKEN_INVALID"
+	CodeTokenExpired        = "AUTH_TOKEN_EXPIRED"
+	CodeUserNotFound        = "AUTH_USER_NOT_FOUND"
+	CodeUserDisabled        = "AUTH_USER_DISABLED"
+	CodeProviderUnavailable = "AUTH_PROVIDER_UNAVAILABLE"
+	CodeMFARequired         = "AUTH_MFA_REQUIRED"
+	CodeMFAInvalid          = "AUTH_MFA_INVALID"
+
+	// Authorization errors (AUTHZ_*)
+	CodeForbidden         = "AUTHZ_FORBIDDEN"
+	CodeInsufficientScope = "AUTHZ_INSUFFICIENT_SCOPE"
+	CodeAdminRequired     = "AUTHZ_ADMIN_REQUIRED"
+
+	// Validation errors (VALIDATION_*)
+	CodeInvalidRequest = "VALIDATION_INVALID_REQUEST"
+	CodeInvalidField   = "VALIDATION_INVALID_FIELD"
+	CodeMissingField   = "VALIDATION_MISSING_FIELD"
+	CodeInvalidFormat  = "VALIDATION_INVALID_FORMAT"
+	CodeOutOfRange     = "VALIDATION_OUT_OF_RANGE"
+	CodeInvalidJSON    = "VALIDATION_INVALID_JSON"
+
+	// Resource errors (RESOURCE_*)
+	CodeResourceNotFound = "RESOURCE_NOT_FOUND"
+	CodeResourceExists   = "RESOURCE_EXISTS"
+	CodeResourceConflict = "RESOURCE_CONFLICT"
+	CodeResourceLocked   = "RESOURCE_LOCKED"
+
+	// PKI errors (PKI_*)
+	CodeCertificateInvalid  = "PKI_CERTIFICATE_INVALID"
+	CodeCertificateExpired  = "PKI_CERTIFICATE_EXPIRED"
+	CodeCertificateRevoked  = "PKI_CERTIFICATE_REVOKED"
+	CodeCANotInitialized    = "PKI_CA_NOT_INITIALIZED"
+	CodeKeyGenerationFailed = "PKI_KEY_GENERATION_FAILED"
+	CodeSigningFailed       = "PKI_SIGNING_FAILED"
+	CodeCRLGenerationFailed = "PKI_CRL_GENERATION_FAILED"
+
+	// Database errors (DB_*)
+	CodeDatabaseError       = "DB_ERROR"
+	CodeConnectionFailed    = "DB_CONNECTION_FAILED"
+	CodeQueryFailed         = "DB_QUERY_FAILED"
+	CodeTransactionFailed   = "DB_TRANSACTION_FAILED"
+	CodeConstraintViolation = "DB_CONSTRAINT_VIOLATION"
+	CodeRecordNotFound      = "DB_RECORD_NOT_FOUND"
+
+	// Gateway errors (GATEWAY_*)
+	CodeGatewayNotFound       = "GATEWAY_NOT_FOUND"
+	CodeGatewayUnreachable    = "GATEWAY_UNREACHABLE"
+	CodeGatewayTokenInvalid   = "GATEWAY_TOKEN_INVALID"
+	CodeGatewayNotProvisioned = "GATEWAY_NOT_PROVISIONED"
+
+	// Rate limiting errors (RATE_*)
+	CodeRateLimitExceeded = "RATE_LIMIT_EXCEEDED"
+	CodeTooManyRequests   = "RATE_TOO_MANY_REQUESTS"
+
+	// Internal errors (INTERNAL_*)
+	CodeInternalError      = "INTERNAL_ERROR"
+	CodeServiceUnavailable = "INTERNAL_SERVICE_UNAVAILABLE"
+	CodeTimeout            = "INTERNAL_TIMEOUT"
+)
+
+// AppError is the base application error type.
+// It implements the error interface and provides structured error information.
+type AppError struct {
+	// Code is a stable error code for programmatic handling
+	Code string `json:"code"`
+
+	// Message is a human-readable error description
+	Message string `json:"message"`
+
+	// Details contains additional context about the error
+	Details map[string]any `json:"details,omitempty"`
+
+	// HTTPStatus is the HTTP status code to return (not serialized to JSON)
+	HTTPStatus int `json:"-"`
+
+	// Err is the underlying error (not serialized to JSON)
+	Err error `json:"-"`
+}
+
+// Error implements the error interface.
+func (e *AppError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("%s: %s: %v", e.Code, e.Message, e.Err)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Unwrap returns the underlying error for use with errors.Is and errors.As.
+func (e *AppError) Unwrap() error {
+	return e.Err
+}
+
+// WithDetails adds details to the error and returns it for chaining.
+func (e *AppError) WithDetails(key string, value any) *AppError {
+	if e.Details == nil {
+		e.Details = make(map[string]any)
+	}
+	e.Details[key] = value
+	return e
+}
+
+// WithError wraps an underlying error and returns it for chaining.
+func (e *AppError) WithError(err error) *AppError {
+	e.Err = err
+	return e
+}
+
+// New creates a new AppError with the given code, message, and HTTP status.
+func New(code, message string, httpStatus int) *AppError {
+	return &AppError{
+		Code:       code,
+		Message:    message,
+		HTTPStatus: httpStatus,
+	}
+}
+
+// Wrap wraps an existing error with an AppError.
+func Wrap(err error, code, message string, httpStatus int) *AppError {
+	return &AppError{
+		Code:       code,
+		Message:    message,
+		HTTPStatus: httpStatus,
+		Err:        err,
+	}
+}
+
+// --- Authentication Errors ---
+
+// ErrInvalidCredentials returns an error for invalid username or password.
+func ErrInvalidCredentials() *AppError {
+	return New(CodeInvalidCredentials, "invalid username or password", http.StatusUnauthorized)
+}
+
+// ErrSessionExpired returns an error for expired sessions.
+func ErrSessionExpired() *AppError {
+	return New(CodeSessionExpired, "session has expired", http.StatusUnauthorized)
+}
+
+// ErrSessionNotFound returns an error when session is not found.
+func ErrSessionNotFound() *AppError {
+	return New(CodeSessionNotFound, "session not found", http.StatusUnauthorized)
+}
+
+// ErrTokenInvalid returns an error for invalid tokens.
+func ErrTokenInvalid() *AppError {
+	return New(CodeTokenInvalid, "invalid or malformed token", http.StatusUnauthorized)
+}
+
+// ErrTokenExpired returns an error for expired tokens.
+func ErrTokenExpired() *AppError {
+	return New(CodeTokenExpired, "token has expired", http.StatusUnauthorized)
+}
+
+// ErrUserNotFound returns an error when user is not found.
+func ErrUserNotFound() *AppError {
+	return New(CodeUserNotFound, "user not found", http.StatusNotFound)
+}
+
+// ErrUserDisabled returns an error when user account is disabled.
+func ErrUserDisabled() *AppError {
+	return New(CodeUserDisabled, "user account is disabled", http.StatusForbidden)
+}
+
+// ErrProviderUnavailable returns an error when auth provider is unavailable.
+func ErrProviderUnavailable(provider string) *AppError {
+	return New(CodeProviderUnavailable, "authentication provider unavailable", http.StatusServiceUnavailable).
+		WithDetails("provider", provider)
+}
+
+// --- Authorization Errors ---
+
+// ErrForbidden returns an error for forbidden access.
+func ErrForbidden() *AppError {
+	return New(CodeForbidden, "access denied", http.StatusForbidden)
+}
+
+// ErrInsufficientScope returns an error for insufficient permissions.
+func ErrInsufficientScope(required string) *AppError {
+	return New(CodeInsufficientScope, "insufficient permissions", http.StatusForbidden).
+		WithDetails("required_scope", required)
+}
+
+// ErrAdminRequired returns an error when admin access is required.
+func ErrAdminRequired() *AppError {
+	return New(CodeAdminRequired, "administrator access required", http.StatusForbidden)
+}
+
+// --- Validation Errors ---
+
+// ErrInvalidRequest returns an error for invalid requests.
+func ErrInvalidRequest(reason string) *AppError {
+	return New(CodeInvalidRequest, reason, http.StatusBadRequest)
+}
+
+// ErrInvalidField returns an error for invalid field values.
+func ErrInvalidField(field, reason string) *AppError {
+	return New(CodeInvalidField, fmt.Sprintf("invalid value for field '%s': %s", field, reason), http.StatusBadRequest).
+		WithDetails("field", field).
+		WithDetails("reason", reason)
+}
+
+// ErrMissingField returns an error for missing required fields.
+func ErrMissingField(field string) *AppError {
+	return New(CodeMissingField, fmt.Sprintf("missing required field '%s'", field), http.StatusBadRequest).
+		WithDetails("field", field)
+}
+
+// ErrInvalidJSON returns an error for invalid JSON.
+func ErrInvalidJSON(err error) *AppError {
+	return Wrap(err, CodeInvalidJSON, "invalid JSON in request body", http.StatusBadRequest)
+}
+
+// --- Resource Errors ---
+
+// ErrResourceNotFound returns an error when a resource is not found.
+func ErrResourceNotFound(resourceType, identifier string) *AppError {
+	return New(CodeResourceNotFound, fmt.Sprintf("%s not found", resourceType), http.StatusNotFound).
+		WithDetails("resource_type", resourceType).
+		WithDetails("identifier", identifier)
+}
+
+// ErrResourceExists returns an error when a resource already exists.
+func ErrResourceExists(resourceType, identifier string) *AppError {
+	return New(CodeResourceExists, fmt.Sprintf("%s already exists", resourceType), http.StatusConflict).
+		WithDetails("resource_type", resourceType).
+		WithDetails("identifier", identifier)
+}
+
+// ErrResourceConflict returns an error for resource conflicts.
+func ErrResourceConflict(reason string) *AppError {
+	return New(CodeResourceConflict, reason, http.StatusConflict)
+}
+
+// --- PKI Errors ---
+
+// ErrCertificateInvalid returns an error for invalid certificates.
+func ErrCertificateInvalid(reason string) *AppError {
+	return New(CodeCertificateInvalid, reason, http.StatusBadRequest).
+		WithDetails("reason", reason)
+}
+
+// ErrCertificateExpired returns an error for expired certificates.
+func ErrCertificateExpired() *AppError {
+	return New(CodeCertificateExpired, "certificate has expired", http.StatusUnauthorized)
+}
+
+// ErrCertificateRevoked returns an error for revoked certificates.
+func ErrCertificateRevoked() *AppError {
+	return New(CodeCertificateRevoked, "certificate has been revoked", http.StatusUnauthorized)
+}
+
+// ErrCANotInitialized returns an error when CA is not initialized.
+func ErrCANotInitialized() *AppError {
+	return New(CodeCANotInitialized, "certificate authority not initialized", http.StatusInternalServerError)
+}
+
+// --- Gateway Errors ---
+
+// ErrGatewayNotFound returns an error when gateway is not found.
+func ErrGatewayNotFound(identifier string) *AppError {
+	return New(CodeGatewayNotFound, "gateway not found", http.StatusNotFound).
+		WithDetails("identifier", identifier)
+}
+
+// ErrGatewayUnreachable returns an error when gateway is unreachable.
+func ErrGatewayUnreachable(identifier string) *AppError {
+	return New(CodeGatewayUnreachable, "gateway is unreachable", http.StatusBadGateway).
+		WithDetails("identifier", identifier)
+}
+
+// ErrGatewayTokenInvalid returns an error for invalid gateway tokens.
+func ErrGatewayTokenInvalid() *AppError {
+	return New(CodeGatewayTokenInvalid, "invalid gateway token", http.StatusUnauthorized)
+}
+
+// --- Rate Limiting Errors ---
+
+// ErrRateLimitExceeded returns an error when rate limit is exceeded.
+func ErrRateLimitExceeded(retryAfter int) *AppError {
+	return New(CodeRateLimitExceeded, "rate limit exceeded", http.StatusTooManyRequests).
+		WithDetails("retry_after_seconds", retryAfter)
+}
+
+// --- Internal Errors ---
+
+// ErrInternal returns an internal server error.
+// The underlying error is logged but not exposed to clients.
+func ErrInternal(err error) *AppError {
+	return Wrap(err, CodeInternalError, "an internal error occurred", http.StatusInternalServerError)
+}
+
+// ErrServiceUnavailable returns a service unavailable error.
+func ErrServiceUnavailable(service string) *AppError {
+	return New(CodeServiceUnavailable, "service temporarily unavailable", http.StatusServiceUnavailable).
+		WithDetails("service", service)
+}
+
+// ErrTimeout returns a timeout error.
+func ErrTimeout(operation string) *AppError {
+	return New(CodeTimeout, "operation timed out", http.StatusGatewayTimeout).
+		WithDetails("operation", operation)
+}
+
+// --- Database Errors ---
+
+// ErrDatabase returns a database error.
+func ErrDatabase(err error) *AppError {
+	return Wrap(err, CodeDatabaseError, "database error", http.StatusInternalServerError)
+}
+
+// ErrRecordNotFound returns an error when a database record is not found.
+func ErrRecordNotFound(table string) *AppError {
+	return New(CodeRecordNotFound, "record not found", http.StatusNotFound).
+		WithDetails("table", table)
+}

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,0 +1,307 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestAppError_Error(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *AppError
+		expected string
+	}{
+		{
+			name:     "without underlying error",
+			err:      New(CodeInvalidCredentials, "invalid credentials", http.StatusUnauthorized),
+			expected: "AUTH_INVALID_CREDENTIALS: invalid credentials",
+		},
+		{
+			name:     "with underlying error",
+			err:      Wrap(errors.New("connection refused"), CodeDatabaseError, "database error", http.StatusInternalServerError),
+			expected: "DB_ERROR: database error: connection refused",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.expected {
+				t.Errorf("Error() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAppError_Unwrap(t *testing.T) {
+	underlying := errors.New("underlying error")
+	appErr := Wrap(underlying, CodeInternalError, "wrapped", http.StatusInternalServerError)
+
+	if !errors.Is(appErr, underlying) {
+		t.Error("errors.Is should find underlying error")
+	}
+}
+
+func TestAppError_WithDetails(t *testing.T) {
+	err := New(CodeInvalidField, "invalid field", http.StatusBadRequest).
+		WithDetails("field", "email").
+		WithDetails("reason", "invalid format")
+
+	if err.Details["field"] != "email" {
+		t.Errorf("Details[field] = %v, want email", err.Details["field"])
+	}
+	if err.Details["reason"] != "invalid format" {
+		t.Errorf("Details[reason] = %v, want 'invalid format'", err.Details["reason"])
+	}
+}
+
+func TestAppError_WithError(t *testing.T) {
+	underlying := errors.New("original error")
+	err := New(CodeInternalError, "internal error", http.StatusInternalServerError).
+		WithError(underlying)
+
+	if err.Err != underlying {
+		t.Error("WithError should set underlying error")
+	}
+}
+
+func TestErrInvalidCredentials(t *testing.T) {
+	err := ErrInvalidCredentials()
+
+	if err.Code != CodeInvalidCredentials {
+		t.Errorf("Code = %s, want %s", err.Code, CodeInvalidCredentials)
+	}
+	if err.HTTPStatus != http.StatusUnauthorized {
+		t.Errorf("HTTPStatus = %d, want %d", err.HTTPStatus, http.StatusUnauthorized)
+	}
+}
+
+func TestErrResourceNotFound(t *testing.T) {
+	err := ErrResourceNotFound("user", "123")
+
+	if err.Code != CodeResourceNotFound {
+		t.Errorf("Code = %s, want %s", err.Code, CodeResourceNotFound)
+	}
+	if err.HTTPStatus != http.StatusNotFound {
+		t.Errorf("HTTPStatus = %d, want %d", err.HTTPStatus, http.StatusNotFound)
+	}
+	if err.Details["resource_type"] != "user" {
+		t.Errorf("Details[resource_type] = %v, want user", err.Details["resource_type"])
+	}
+	if err.Details["identifier"] != "123" {
+		t.Errorf("Details[identifier] = %v, want 123", err.Details["identifier"])
+	}
+}
+
+func TestErrResourceExists(t *testing.T) {
+	err := ErrResourceExists("user", "john@example.com")
+
+	if err.Code != CodeResourceExists {
+		t.Errorf("Code = %s, want %s", err.Code, CodeResourceExists)
+	}
+	if err.HTTPStatus != http.StatusConflict {
+		t.Errorf("HTTPStatus = %d, want %d", err.HTTPStatus, http.StatusConflict)
+	}
+}
+
+func TestErrInvalidField(t *testing.T) {
+	err := ErrInvalidField("email", "must be a valid email address")
+
+	if err.Code != CodeInvalidField {
+		t.Errorf("Code = %s, want %s", err.Code, CodeInvalidField)
+	}
+	if err.Details["field"] != "email" {
+		t.Errorf("Details[field] = %v, want email", err.Details["field"])
+	}
+}
+
+func TestErrMissingField(t *testing.T) {
+	err := ErrMissingField("username")
+
+	if err.Code != CodeMissingField {
+		t.Errorf("Code = %s, want %s", err.Code, CodeMissingField)
+	}
+	if err.Details["field"] != "username" {
+		t.Errorf("Details[field] = %v, want username", err.Details["field"])
+	}
+}
+
+func TestErrInvalidJSON(t *testing.T) {
+	underlying := errors.New("unexpected EOF")
+	err := ErrInvalidJSON(underlying)
+
+	if err.Code != CodeInvalidJSON {
+		t.Errorf("Code = %s, want %s", err.Code, CodeInvalidJSON)
+	}
+	if !errors.Is(err, underlying) {
+		t.Error("should wrap underlying error")
+	}
+}
+
+func TestErrForbidden(t *testing.T) {
+	err := ErrForbidden()
+
+	if err.Code != CodeForbidden {
+		t.Errorf("Code = %s, want %s", err.Code, CodeForbidden)
+	}
+	if err.HTTPStatus != http.StatusForbidden {
+		t.Errorf("HTTPStatus = %d, want %d", err.HTTPStatus, http.StatusForbidden)
+	}
+}
+
+func TestErrInsufficientScope(t *testing.T) {
+	err := ErrInsufficientScope("admin:write")
+
+	if err.Code != CodeInsufficientScope {
+		t.Errorf("Code = %s, want %s", err.Code, CodeInsufficientScope)
+	}
+	if err.Details["required_scope"] != "admin:write" {
+		t.Errorf("Details[required_scope] = %v, want admin:write", err.Details["required_scope"])
+	}
+}
+
+func TestErrRateLimitExceeded(t *testing.T) {
+	err := ErrRateLimitExceeded(60)
+
+	if err.Code != CodeRateLimitExceeded {
+		t.Errorf("Code = %s, want %s", err.Code, CodeRateLimitExceeded)
+	}
+	if err.HTTPStatus != http.StatusTooManyRequests {
+		t.Errorf("HTTPStatus = %d, want %d", err.HTTPStatus, http.StatusTooManyRequests)
+	}
+	if err.Details["retry_after_seconds"] != 60 {
+		t.Errorf("Details[retry_after_seconds] = %v, want 60", err.Details["retry_after_seconds"])
+	}
+}
+
+func TestErrInternal(t *testing.T) {
+	underlying := errors.New("nil pointer dereference")
+	err := ErrInternal(underlying)
+
+	if err.Code != CodeInternalError {
+		t.Errorf("Code = %s, want %s", err.Code, CodeInternalError)
+	}
+	if err.HTTPStatus != http.StatusInternalServerError {
+		t.Errorf("HTTPStatus = %d, want %d", err.HTTPStatus, http.StatusInternalServerError)
+	}
+	// Should not expose underlying error in message
+	if err.Message == underlying.Error() {
+		t.Error("should not expose underlying error in message")
+	}
+	// But should be unwrappable
+	if !errors.Is(err, underlying) {
+		t.Error("should wrap underlying error")
+	}
+}
+
+func TestErrGatewayNotFound(t *testing.T) {
+	err := ErrGatewayNotFound("gw-123")
+
+	if err.Code != CodeGatewayNotFound {
+		t.Errorf("Code = %s, want %s", err.Code, CodeGatewayNotFound)
+	}
+	if err.Details["identifier"] != "gw-123" {
+		t.Errorf("Details[identifier] = %v, want gw-123", err.Details["identifier"])
+	}
+}
+
+func TestErrCertificateInvalid(t *testing.T) {
+	err := ErrCertificateInvalid("certificate is not a CA")
+
+	if err.Code != CodeCertificateInvalid {
+		t.Errorf("Code = %s, want %s", err.Code, CodeCertificateInvalid)
+	}
+	if err.Details["reason"] != "certificate is not a CA" {
+		t.Errorf("Details[reason] = %v, want 'certificate is not a CA'", err.Details["reason"])
+	}
+}
+
+func TestErrProviderUnavailable(t *testing.T) {
+	err := ErrProviderUnavailable("oidc")
+
+	if err.Code != CodeProviderUnavailable {
+		t.Errorf("Code = %s, want %s", err.Code, CodeProviderUnavailable)
+	}
+	if err.Details["provider"] != "oidc" {
+		t.Errorf("Details[provider] = %v, want oidc", err.Details["provider"])
+	}
+}
+
+func TestIsAppError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		code     string
+		expected bool
+	}{
+		{
+			name:     "matching AppError",
+			err:      ErrInvalidCredentials(),
+			code:     CodeInvalidCredentials,
+			expected: true,
+		},
+		{
+			name:     "non-matching AppError",
+			err:      ErrInvalidCredentials(),
+			code:     CodeForbidden,
+			expected: false,
+		},
+		{
+			name:     "wrapped AppError",
+			err:      fmt.Errorf("wrapped: %w", ErrInvalidCredentials()),
+			code:     CodeInvalidCredentials,
+			expected: true,
+		},
+		{
+			name:     "regular error",
+			err:      errors.New("regular error"),
+			code:     CodeInternalError,
+			expected: false,
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			code:     CodeInternalError,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsAppError(tt.err, tt.code); got != tt.expected {
+				t.Errorf("IsAppError() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetAppError(t *testing.T) {
+	t.Run("returns AppError", func(t *testing.T) {
+		err := ErrInvalidCredentials()
+		if got := GetAppError(err); got != err {
+			t.Errorf("GetAppError() = %v, want %v", got, err)
+		}
+	})
+
+	t.Run("returns wrapped AppError", func(t *testing.T) {
+		appErr := ErrInvalidCredentials()
+		wrapped := fmt.Errorf("wrapped: %w", appErr)
+		if got := GetAppError(wrapped); got != appErr {
+			t.Errorf("GetAppError() = %v, want %v", got, appErr)
+		}
+	})
+
+	t.Run("returns nil for regular error", func(t *testing.T) {
+		err := errors.New("regular error")
+		if got := GetAppError(err); got != nil {
+			t.Errorf("GetAppError() = %v, want nil", got)
+		}
+	})
+
+	t.Run("returns nil for nil error", func(t *testing.T) {
+		if got := GetAppError(nil); got != nil {
+			t.Errorf("GetAppError() = %v, want nil", got)
+		}
+	})
+}

--- a/internal/errors/response.go
+++ b/internal/errors/response.go
@@ -1,0 +1,102 @@
+package errors
+
+import (
+	"errors"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ErrorResponse is the structured JSON error response format.
+type ErrorResponse struct {
+	Error ErrorBody `json:"error"`
+}
+
+// ErrorBody contains the error details.
+type ErrorBody struct {
+	Code    string         `json:"code"`
+	Message string         `json:"message"`
+	Details map[string]any `json:"details,omitempty"`
+}
+
+// RespondWithError writes an AppError as a JSON response.
+// It sets the appropriate HTTP status code and returns a structured error response.
+//
+// Usage:
+//
+//	if err != nil {
+//	    apperrors.RespondWithError(c, apperrors.ErrInvalidCredentials())
+//	    return
+//	}
+func RespondWithError(c *gin.Context, err *AppError) {
+	c.JSON(err.HTTPStatus, ErrorResponse{
+		Error: ErrorBody{
+			Code:    err.Code,
+			Message: err.Message,
+			Details: err.Details,
+		},
+	})
+}
+
+// AbortWithError aborts the request with an AppError.
+// This is useful in middleware where you want to stop further processing.
+//
+// Usage:
+//
+//	if !authorized {
+//	    apperrors.AbortWithError(c, apperrors.ErrForbidden())
+//	    return
+//	}
+func AbortWithError(c *gin.Context, err *AppError) {
+	c.AbortWithStatusJSON(err.HTTPStatus, ErrorResponse{
+		Error: ErrorBody{
+			Code:    err.Code,
+			Message: err.Message,
+			Details: err.Details,
+		},
+	})
+}
+
+// HandleError inspects an error and responds appropriately.
+// If the error is an *AppError, it uses its code and status.
+// Otherwise, it wraps it as an internal error.
+//
+// Usage:
+//
+//	if err := service.DoSomething(); err != nil {
+//	    apperrors.HandleError(c, err)
+//	    return
+//	}
+func HandleError(c *gin.Context, err error) {
+	var appErr *AppError
+	if errors.As(err, &appErr) {
+		RespondWithError(c, appErr)
+		return
+	}
+	// Wrap unknown errors as internal errors
+	RespondWithError(c, ErrInternal(err))
+}
+
+// IsAppError checks if an error is an *AppError with a specific code.
+//
+// Usage:
+//
+//	if apperrors.IsAppError(err, apperrors.CodeUserNotFound) {
+//	    // Handle user not found case
+//	}
+func IsAppError(err error, code string) bool {
+	var appErr *AppError
+	if errors.As(err, &appErr) {
+		return appErr.Code == code
+	}
+	return false
+}
+
+// GetAppError extracts an *AppError from an error chain.
+// Returns nil if no AppError is found.
+func GetAppError(err error) *AppError {
+	var appErr *AppError
+	if errors.As(err, &appErr) {
+		return appErr
+	}
+	return nil
+}

--- a/internal/errors/response_test.go
+++ b/internal/errors/response_test.go
@@ -1,0 +1,205 @@
+package errors
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func TestRespondWithError(t *testing.T) {
+	tests := []struct {
+		name           string
+		err            *AppError
+		expectedStatus int
+		expectedCode   string
+	}{
+		{
+			name:           "unauthorized error",
+			err:            ErrInvalidCredentials(),
+			expectedStatus: http.StatusUnauthorized,
+			expectedCode:   CodeInvalidCredentials,
+		},
+		{
+			name:           "not found error",
+			err:            ErrResourceNotFound("user", "123"),
+			expectedStatus: http.StatusNotFound,
+			expectedCode:   CodeResourceNotFound,
+		},
+		{
+			name:           "bad request error",
+			err:            ErrInvalidField("email", "invalid format"),
+			expectedStatus: http.StatusBadRequest,
+			expectedCode:   CodeInvalidField,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+
+			RespondWithError(c, tt.err)
+
+			if w.Code != tt.expectedStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.expectedStatus)
+			}
+
+			var resp ErrorResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("failed to unmarshal response: %v", err)
+			}
+
+			if resp.Error.Code != tt.expectedCode {
+				t.Errorf("code = %s, want %s", resp.Error.Code, tt.expectedCode)
+			}
+		})
+	}
+}
+
+func TestRespondWithError_WithDetails(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	err := ErrResourceNotFound("gateway", "gw-123")
+	RespondWithError(c, err)
+
+	var resp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Error.Details["resource_type"] != "gateway" {
+		t.Errorf("details[resource_type] = %v, want gateway", resp.Error.Details["resource_type"])
+	}
+	if resp.Error.Details["identifier"] != "gw-123" {
+		t.Errorf("details[identifier] = %v, want gw-123", resp.Error.Details["identifier"])
+	}
+}
+
+func TestAbortWithError(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	AbortWithError(c, ErrForbidden())
+
+	if !c.IsAborted() {
+		t.Error("context should be aborted")
+	}
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+
+	var resp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Error.Code != CodeForbidden {
+		t.Errorf("code = %s, want %s", resp.Error.Code, CodeForbidden)
+	}
+}
+
+func TestHandleError_AppError(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	HandleError(c, ErrInvalidCredentials())
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+
+	var resp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Error.Code != CodeInvalidCredentials {
+		t.Errorf("code = %s, want %s", resp.Error.Code, CodeInvalidCredentials)
+	}
+}
+
+func TestHandleError_RegularError(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	HandleError(c, errors.New("some internal error"))
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+
+	var resp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Error.Code != CodeInternalError {
+		t.Errorf("code = %s, want %s", resp.Error.Code, CodeInternalError)
+	}
+
+	// Should not expose internal error details
+	if resp.Error.Message == "some internal error" {
+		t.Error("should not expose internal error message")
+	}
+}
+
+func TestErrorResponseJSON(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	err := ErrRateLimitExceeded(30)
+	RespondWithError(c, err)
+
+	// Verify JSON structure
+	expected := `{"error":{"code":"RATE_LIMIT_EXCEEDED","message":"rate limit exceeded","details":{"retry_after_seconds":30}}}`
+
+	var gotJSON, expectedJSON map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &gotJSON); err != nil {
+		t.Fatalf("failed to unmarshal got: %v", err)
+	}
+	if err := json.Unmarshal([]byte(expected), &expectedJSON); err != nil {
+		t.Fatalf("failed to unmarshal expected: %v", err)
+	}
+
+	gotError := gotJSON["error"].(map[string]any)
+	expectedError := expectedJSON["error"].(map[string]any)
+
+	if gotError["code"] != expectedError["code"] {
+		t.Errorf("code mismatch: got %v, want %v", gotError["code"], expectedError["code"])
+	}
+	if gotError["message"] != expectedError["message"] {
+		t.Errorf("message mismatch: got %v, want %v", gotError["message"], expectedError["message"])
+	}
+}
+
+func TestErrorResponse_OmitsEmptyDetails(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	err := ErrForbidden() // No details
+	RespondWithError(c, err)
+
+	body := w.Body.String()
+	if contains(body, "details") {
+		t.Errorf("response should omit empty details, got: %s", body)
+	}
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Add `internal/errors` package with structured error types for consistent API error responses.

### Features

- **Structured AppError type** with code, message, details, and HTTP status
- **Stable error codes** for client-side programmatic handling
- **Gin integration helpers** for easy use in handlers
- **Compatible with errors.Is/As** for error chain inspection

### Error Code Categories

| Category | Prefix | Examples |
|----------|--------|----------|
| Authentication | `AUTH_*` | `AUTH_INVALID_CREDENTIALS`, `AUTH_SESSION_EXPIRED` |
| Authorization | `AUTHZ_*` | `AUTHZ_FORBIDDEN`, `AUTHZ_ADMIN_REQUIRED` |
| Validation | `VALIDATION_*` | `VALIDATION_INVALID_FIELD`, `VALIDATION_MISSING_FIELD` |
| Resources | `RESOURCE_*` | `RESOURCE_NOT_FOUND`, `RESOURCE_EXISTS` |
| PKI | `PKI_*` | `PKI_CERTIFICATE_INVALID`, `PKI_CERTIFICATE_REVOKED` |
| Gateway | `GATEWAY_*` | `GATEWAY_NOT_FOUND`, `GATEWAY_UNREACHABLE` |
| Database | `DB_*` | `DB_CONNECTION_FAILED`, `DB_RECORD_NOT_FOUND` |
| Rate Limiting | `RATE_*` | `RATE_LIMIT_EXCEEDED` |
| Internal | `INTERNAL_*` | `INTERNAL_ERROR`, `INTERNAL_TIMEOUT` |

### JSON Response Format

```json
{
  "error": {
    "code": "AUTH_INVALID_CREDENTIALS",
    "message": "invalid username or password",
    "details": {
      "field": "password"
    }
  }
}
```

### Usage Example

```go
import apperrors "github.com/gatekey-project/gatekey/internal/errors"

func LoginHandler(c *gin.Context) {
    user, err := auth.Authenticate(username, password)
    if err != nil {
        apperrors.RespondWithError(c, apperrors.ErrInvalidCredentials())
        return
    }
    // ...
}
```

## Benefits

- Clients can handle errors programmatically using stable error codes
- Consistent error format across all API endpoints
- Better debugging with structured error details
- Internal errors are wrapped but not exposed to clients

## Test plan

- [x] All tests pass (`go test ./internal/errors/...`)
- [x] Build passes (`go build ./...`)
- [x] go vet clean
- [x] gofmt clean