### PR TITLE
Fix WireGuard hub routing: enable forwarding, disable rp_filter, add NAT

### DIFF
--- a/internal/wireguard/interface.go
+++ b/internal/wireguard/interface.go
@@ -3,6 +3,7 @@ package wireguard
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"strings"
 	"time"
@@ -94,6 +95,62 @@ func (m *InterfaceManager) Setup(ctx context.Context, config InterfaceConfig) er
 		return fmt.Errorf("failed to bring up interface: %w", err)
 	}
 
+	// 6. Configure networking for routing/forwarding
+	if err := m.configureRouting(ctx); err != nil {
+		if m.logger != nil {
+			m.logger.Warn("Failed to configure routing (may require manual setup)", zap.Error(err))
+		}
+	}
+
+	return nil
+}
+
+// configureRouting enables IP forwarding and disables reverse path filtering
+// on the WireGuard interface so VPN traffic can be routed to the LAN.
+func (m *InterfaceManager) configureRouting(ctx context.Context) error {
+	// Enable IP forwarding
+	if err := m.executor.Run(ctx, "sysctl", "-w", "net.ipv4.ip_forward=1"); err != nil {
+		return fmt.Errorf("failed to enable IP forwarding: %w", err)
+	}
+
+	// Disable reverse path filtering on the WireGuard interface
+	// rp_filter=1 (strict) drops packets where the source address would not be
+	// routed back via the same interface, which breaks VPN forwarding
+	rpFilterKey := fmt.Sprintf("net.ipv4.conf.%s.rp_filter=0", m.name)
+	if err := m.executor.Run(ctx, "sysctl", "-w", rpFilterKey); err != nil {
+		return fmt.Errorf("failed to disable rp_filter: %w", err)
+	}
+
+	// Add NAT masquerade for VPN traffic exiting to the LAN
+	// This ensures reply packets from LAN hosts are routed back through the hub
+	if m.config.Address != "" {
+		// Extract subnet from address (e.g., "172.30.0.1/16" -> "172.30.0.0/16")
+		parts := strings.SplitN(m.config.Address, "/", 2)
+		if len(parts) == 2 {
+			ip := net.ParseIP(parts[0])
+			if ip != nil {
+				_, ipNet, err := net.ParseCIDR(m.config.Address)
+				if err == nil {
+					subnet := ipNet.String()
+					// Check if masquerade rule already exists before adding
+					checkErr := m.executor.Run(ctx, "iptables", "-t", "nat", "-C", "POSTROUTING",
+						"-s", subnet, "-o", "eth0", "-j", "MASQUERADE")
+					if checkErr != nil {
+						// Rule doesn't exist, add it
+						if err := m.executor.Run(ctx, "iptables", "-t", "nat", "-A", "POSTROUTING",
+							"-s", subnet, "!", "-o", m.name, "-j", "MASQUERADE"); err != nil {
+							return fmt.Errorf("failed to add masquerade rule: %w", err)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if m.logger != nil {
+		m.logger.Info("Routing configured for VPN forwarding",
+			zap.String("interface", m.name))
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

The WireGuard mesh hub VPN tunnel established handshakes but no IP traffic passed through. Three host networking issues prevented traffic flow:

1. **`rp_filter=1` (strict)** on the wg interface — the kernel dropped decrypted VPN packets because the reverse path check failed (VPN source IPs aren't routable back via the same interface for forwarded traffic)
2. **No NAT masquerade** — LAN hosts received packets from VPN client IPs (`172.30.0.x`) but had no return route, so replies were dropped
3. **IP forwarding** — needed to be explicitly enabled for the hub to act as a router

The fix adds a `configureRouting()` step to the WireGuard interface setup that automatically:
- Enables `net.ipv4.ip_forward`
- Sets `net.ipv4.conf.<iface>.rp_filter=0`
- Adds `iptables -t nat -A POSTROUTING -s <vpn_subnet> ! -o <wg_iface> -j MASQUERADE`

Also stopped and disabled the legacy OpenVPN service on the hub host which was conflicting with the same `172.30.0.0/16` subnet on `tun0`.

## Test plan

- [x] VPN tunnel handshake completes (verified via `wg show`)
- [x] Phone can ping hub (`192.168.50.100`) through tunnel
- [x] Phone can ping cluster nodes (`192.168.50.11`) through tunnel
- [ ] Restart `gatekey-wireguard-hub` and verify routing auto-configures
- [ ] Verify existing spoke connections still work after restart