### PR TITLE
fix(mesh-gateway): forward tunnel traffic to local networks

### DIFF
--- a/cmd/gatekey-wireguard-mesh-gateway/main.go
+++ b/cmd/gatekey-wireguard-mesh-gateway/main.go
@@ -669,6 +669,15 @@ func setupInterface(ctx context.Context) error {
 		logger.Warn("Failed to setup NAT", zap.Error(err))
 	}
 
+	// Allow packets to be forwarded between the tunnel and local networks.
+	// Without this, hosts whose FORWARD policy is DROP (Docker installs one,
+	// and many cloud AMIs default to it) silently drop all wg0<->LAN traffic
+	// even though the tunnel is up, so clients can never reach the local
+	// networks this gateway serves.
+	if err := setupForwarding(ctx); err != nil {
+		logger.Warn("Failed to setup forwarding rules", zap.Error(err))
+	}
+
 	logger.Info("WireGuard interface setup complete",
 		zap.String("address", tunnelAddr),
 		zap.String("hub", hubEndpoint),
@@ -754,6 +763,67 @@ func setupNAT(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// setupForwarding installs FORWARD-chain accept rules so packets can traverse
+// between the WireGuard tunnel (interfaceName) and the local networks this
+// gateway serves.
+//
+// Unlike the other GateKey gateway binaries, the mesh gateway does not pull in
+// the policy-enforcing internal/firewall manager; it previously relied only on
+// masquerade plus the host's default FORWARD policy. On hosts where that policy
+// is DROP, forwarded VPN traffic is silently dropped and clients cannot reach
+// the local networks behind this gateway even though the tunnel is up. These
+// rules make forwarding explicit. IPv6 is best-effort.
+func setupForwarding(ctx context.Context) error {
+	if err := ensureForwardAccept(ctx, "iptables"); err != nil {
+		return err
+	}
+	// IPv6 forwarding is only meaningful when IPv6 networks are in play; a
+	// failure here (e.g. ip6tables absent) must not block IPv4 connectivity.
+	if err := ensureForwardAccept(ctx, "ip6tables"); err != nil {
+		logger.Debug("IPv6 forwarding rules not applied", zap.Error(err))
+	}
+	return nil
+}
+
+// ensureForwardAccept idempotently inserts ACCEPT rules for tunnel<->LAN
+// forwarding using the given iptables-compatible binary (iptables or ip6tables):
+//   - established/related return traffic
+//   - anything arriving on the WireGuard interface (tunnel -> local)
+//   - anything leaving on the WireGuard interface (local -> tunnel)
+//
+// Rules are inserted at the top of the FORWARD chain (-I FORWARD 1) so they take
+// effect regardless of an existing DROP policy or later drop rules, and are
+// checked with -C first so re-runs do not create duplicates.
+func ensureForwardAccept(ctx context.Context, ipt string) error {
+	rules := [][]string{
+		{"-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"},
+		{"-i", interfaceName, "-j", "ACCEPT"},
+		{"-o", interfaceName, "-j", "ACCEPT"},
+	}
+
+	var lastErr error
+	for _, rule := range rules {
+		// Skip if an identical rule already exists.
+		checkArgs := append([]string{"-C", "FORWARD"}, rule...)
+		if exec.CommandContext(ctx, ipt, checkArgs...).Run() == nil {
+			continue
+		}
+
+		insertArgs := append([]string{"-I", "FORWARD", "1"}, rule...)
+		if output, err := exec.CommandContext(ctx, ipt, insertArgs...).CombinedOutput(); err != nil {
+			// Keep going: the essential -i/-o wg rules must still be applied
+			// even if, say, the conntrack match is unavailable.
+			lastErr = fmt.Errorf("%s FORWARD %v: %s: %w", ipt, rule, strings.TrimSpace(string(output)), err)
+			logger.Debug("FORWARD accept rule failed", zap.String("cmd", ipt), zap.Strings("rule", rule), zap.Error(lastErr))
+			continue
+		}
+
+		logger.Info("Added FORWARD accept rule", zap.String("cmd", ipt), zap.Strings("rule", rule))
+	}
+
+	return lastErr
 }
 
 func setupNftablesNAT(ctx context.Context, vpnSubnet, outIface string) error {


### PR DESCRIPTION
## Problem

The GateKey **WireGuard mesh gateway (spoke)** connects to the hub fine, reports `online`, but **no traffic reaches the local networks it serves** (peer transfer stays `0/0`). Observed live: hub `hub` (advertises `192.168.50.0/23`) ↔ spoke `petfriend` (AWS VM, advertises `10.0.0.0/16`, tunnel IP `172.30.0.2`) — split tunnel, handshake up, `bytes_sent=0 / bytes_received=0`, and `10.0.0.0/16` unreachable from behind the hub.

## Root cause

`cmd/gatekey-wireguard-mesh-gateway` is the **only** VPN binary that never sets up any FORWARD-chain rules. The others (`gatekey-wireguard-gateway`, `gatekey-wireguard-hub`, `gatekey-gateway`, `gatekey-hub`) import `internal/firewall` and install an nftables `forward` chain. The mesh gateway relied solely on:

- `setupNAT()` → POSTROUTING `MASQUERADE`, and
- `setupRoutes()` → `ip route add … dev wg0`

…plus the host's **default FORWARD policy being ACCEPT**. On any host where that policy is **DROP** — Docker installs one; many hardened/cloud AMIs default to it — every `wg0 → 10.0.0.0/16` packet is dropped before it ever reaches POSTROUTING. Tunnel up, zero forwarding.

## Fix

Add `setupForwarding()`, invoked from `setupInterface()` right after `setupNAT()`. It idempotently inserts ACCEPT rules at the **top** of the FORWARD chain:

- established/related return traffic
- ingress on the WireGuard interface (tunnel → local)
- egress on the WireGuard interface (local → tunnel)

Rules use `-I FORWARD 1` so they take precedence over an existing DROP policy / later drop rules, and are checked with `-C` first so re-runs don't create duplicates. IPv6 (`ip6tables`) is best-effort and never blocks IPv4 connectivity.

## Testing

- `go build ./cmd/gatekey-wireguard-mesh-gateway/` — OK
- `go vet ./cmd/gatekey-wireguard-mesh-gateway/` — clean
- `gofmt` — clean

After deploying the rebuilt binary to the spoke, traffic from hub clients reaches `10.0.0.0/16` and peer transfer counters advance.