### PR TITLE
fix(wireguard): harden interface routing/forwarding setup

### DIFF
--- a/internal/wireguard/interface.go
+++ b/internal/wireguard/interface.go
@@ -113,12 +113,20 @@ func (m *InterfaceManager) configureRouting(ctx context.Context) error {
 		return fmt.Errorf("failed to enable IP forwarding: %w", err)
 	}
 
-	// Disable reverse path filtering on the WireGuard interface
-	// rp_filter=1 (strict) drops packets where the source address would not be
-	// routed back via the same interface, which breaks VPN forwarding
-	rpFilterKey := fmt.Sprintf("net.ipv4.conf.%s.rp_filter=0", m.name)
-	if err := m.executor.Run(ctx, "sysctl", "-w", rpFilterKey); err != nil {
-		return fmt.Errorf("failed to disable rp_filter: %w", err)
+	// Disable reverse path filtering so asymmetrically-routed VPN traffic is
+	// not dropped. rp_filter=1 (strict) drops packets whose source address
+	// would not be routed back via the same interface, which breaks VPN
+	// forwarding. The kernel uses max(conf.all.rp_filter, conf.<iface>.rp_filter)
+	// as the effective value, so setting only the per-interface key is a no-op
+	// when conf.all is strict (the default on many distros) -- relax both.
+	rpFilterKeys := []string{
+		"net.ipv4.conf.all.rp_filter=0",
+		fmt.Sprintf("net.ipv4.conf.%s.rp_filter=0", m.name),
+	}
+	for _, key := range rpFilterKeys {
+		if err := m.executor.Run(ctx, "sysctl", "-w", key); err != nil {
+			return fmt.Errorf("failed to disable rp_filter (%s): %w", key, err)
+		}
 	}
 
 	// Add NAT masquerade for VPN traffic exiting to the LAN
@@ -132,9 +140,12 @@ func (m *InterfaceManager) configureRouting(ctx context.Context) error {
 				_, ipNet, err := net.ParseCIDR(m.config.Address)
 				if err == nil {
 					subnet := ipNet.String()
-					// Check if masquerade rule already exists before adding
+					// Check if masquerade rule already exists before adding.
+					// The check must use the exact same predicate as the add
+					// ("! -o <wg iface>", not "-o eth0"); otherwise it never
+					// matches and a duplicate rule is appended on every re-setup.
 					checkErr := m.executor.Run(ctx, "iptables", "-t", "nat", "-C", "POSTROUTING",
-						"-s", subnet, "-o", "eth0", "-j", "MASQUERADE")
+						"-s", subnet, "!", "-o", m.name, "-j", "MASQUERADE")
 					if checkErr != nil {
 						// Rule doesn't exist, add it
 						if err := m.executor.Run(ctx, "iptables", "-t", "nat", "-A", "POSTROUTING",
@@ -396,6 +407,17 @@ func (m *InterfaceManager) AddPeer(ctx context.Context, peer PeerConfig) error {
 
 // addRouteForAllowedIP adds a route for an AllowedIP if it's a network range
 func (m *InterfaceManager) addRouteForAllowedIP(ctx context.Context, allowedIP string) error {
+	// Never inject a default route into the main table here. A naive
+	// "ip route add 0.0.0.0/0 dev <wg iface>" clobbers the host's real default
+	// route and creates a routing loop -- the encrypted WireGuard packets to the
+	// peer's endpoint get matched by the default route and sent back into the
+	// tunnel, so the handshake never completes. Full-tunnel routing requires
+	// policy routing (fwmark + a dedicated table, the wg-quick approach) and is
+	// the gateway agent's responsibility, not this helper's.
+	if allowedIP == "0.0.0.0/0" || allowedIP == "::/0" {
+		return nil
+	}
+
 	// Skip single host addresses (/32 for IPv4, /128 for IPv6) that are in the VPN subnet
 	// These are typically peer tunnel IPs and don't need explicit routes
 	if strings.HasSuffix(allowedIP, "/32") || strings.HasSuffix(allowedIP, "/128") {

--- a/internal/wireguard/interface_defaultroute_test.go
+++ b/internal/wireguard/interface_defaultroute_test.go
@@ -1,0 +1,68 @@
+package wireguard
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// TestAddPeer_SkipsDefaultRoute verifies that AddPeer never issues an
+// "ip route add" for a default route (0.0.0.0/0 or ::/0). Injecting a default
+// route into the main table clobbers the host's real default route and creates
+// a routing loop that prevents the WireGuard handshake from completing. Normal
+// subnet AllowedIPs must still get their routes; /32 and /128 host routes are
+// skipped.
+func TestAddPeer_SkipsDefaultRoute(t *testing.T) {
+	ctx := context.Background()
+
+	var routeAdds []string
+	mock := &mockExecutor{
+		outputFunc: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			if name == "ip" && len(args) >= 3 && args[0] == "route" && args[1] == "add" {
+				routeAdds = append(routeAdds, args[2])
+			}
+			return []byte{}, nil
+		},
+	}
+
+	m := NewInterfaceManagerWithExecutor("wg0", zap.NewNop(), mock)
+
+	peer := PeerConfig{
+		PublicKey: "dGVzdHB1YmxpY2tleXRlc3RwdWJsaWNrZXl0ZXN0MTI9",
+		Endpoint:  "hub.example.com:51820",
+		AllowedIPs: []string{
+			"0.0.0.0/0",     // default route -> must be skipped
+			"::/0",          // IPv6 default route -> must be skipped
+			"172.30.0.2/32", // host route -> skipped (single host)
+			"10.0.0.0/16",   // real subnet -> must be routed
+		},
+	}
+
+	if err := m.AddPeer(ctx, peer); err != nil {
+		t.Fatalf("AddPeer returned error: %v", err)
+	}
+
+	for _, r := range routeAdds {
+		if r == "0.0.0.0/0" || r == "::/0" {
+			t.Errorf("AddPeer added a default route %q; it must never touch the default route", r)
+		}
+	}
+
+	if !contains(routeAdds, "10.0.0.0/16") {
+		t.Errorf("AddPeer did not add route for real subnet 10.0.0.0/16; got routes: %v", routeAdds)
+	}
+	if contains(routeAdds, "172.30.0.2/32") {
+		t.Errorf("AddPeer added a /32 host route %q; host routes should be skipped", "172.30.0.2/32")
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if strings.EqualFold(h, needle) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Three related fixes in the shared `InterfaceManager` (`internal/wireguard/interface.go`), used by every WireGuard gateway binary (hub, gateway, mesh-gateway). These harden the data-plane setup that decides whether VPN traffic actually reaches the networks behind a gateway.

### 1. `rp_filter` relaxed on `conf.all`, not just the interface
`configureRouting()` set only `net.ipv4.conf.<iface>.rp_filter=0`. The kernel uses **`max(conf.all.rp_filter, conf.<iface>.rp_filter)`** as the effective value, so when `conf.all.rp_filter` is strict (the default on many distros) the per-interface setting is a **no-op** and strict reverse-path filtering silently drops asymmetrically-routed VPN traffic. Now relaxes both.

### 2. MASQUERADE idempotency
The POSTROUTING existence check used `-o eth0` while the rule that gets added uses `! -o <wg iface>`. The `-C` check could never match the rule it adds, so a **duplicate MASQUERADE rule was appended on every (re)setup** (and the check hardcoded `eth0`, wrong on AWS/`ens*`, `enp*`). Check and add now use the same predicate.

### 3. Default-route guard in `addRouteForAllowedIP`
`AddPeer()` calls `addRouteForAllowedIP()` for every AllowedIP, and it only skipped `/32` and `/128`. A full-tunnel peer (AllowedIPs `0.0.0.0/0`, `::/0`) therefore triggered `ip route add 0.0.0.0/0 dev wg0`, which **clobbers the host's real default route and creates a routing loop** — the encrypted WireGuard packets to the peer endpoint match the default route and get sent back into the tunnel, so the handshake never completes. This is called from the periodic peer-sync loops, so it re-fires repeatedly ("the default route keeps getting messed up"). Now skips `0.0.0.0/0` and `::/0`; proper full-tunnel routing (fwmark + dedicated table) belongs in the gateway agent.

## Testing

- New `TestAddPeer_SkipsDefaultRoute` — asserts no `ip route add` for `0.0.0.0/0`/`::/0`, real subnets still routed, `/32` still skipped.
- `go test ./internal/wireguard/` — pass
- Builds: `gatekey-wireguard-hub`, `gatekey-wireguard-gateway`, `gatekey-wireguard-mesh-gateway` — OK; `gofmt`/`go vet` clean.

## Relationship to #142
#142 adds the missing FORWARD-chain accept rules to the mesh gateway (the primary root cause of "connects but no traffic reaches the LAN"). This PR hardens the shared routing/NAT/rp_filter setup those rules depend on. The two are complementary and independent.