### PR TITLE
feat(docker): distroless (Chainguard) image for the server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,7 @@ jobs:
             binary: gatekey-server
             deps: ca-certificates tzdata
             tag: gatekey-server:test
+            dockerfile: ./Dockerfile.server
           - name: Gateway
             binary: gatekey-gateway
             deps: ca-certificates tzdata openvpn nftables iptables iproute2
@@ -224,7 +225,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: ./Dockerfile
+          file: ${{ matrix.image.dockerfile || './Dockerfile' }}
           build-args: |
             BINARY=${{ matrix.image.binary }}
             RUNTIME_DEPS=${{ matrix.image.deps }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
             deps: ca-certificates tzdata
             title: GateKey Server
             description: GateKey Zero-Trust VPN Control Plane
+            dockerfile: ./Dockerfile.server
           - image: gatekey-gateway
             binary: gatekey-gateway
             deps: ca-certificates tzdata openvpn nftables iptables iproute2
@@ -99,7 +100,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: ./Dockerfile
+          file: ${{ matrix.dockerfile || './Dockerfile' }}
           build-args: |
             BINARY=${{ matrix.binary }}
             RUNTIME_DEPS=${{ matrix.deps }}

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,0 +1,42 @@
+# GateKey control-plane server image — Chainguard distroless.
+#
+# The server is a pure-Go, CGO-free binary whose only runtime needs are a CA
+# bundle and timezone data. That makes it a perfect fit for a distroless base:
+# no shell, no package manager, no busybox — a minimal attack surface and a
+# near-zero-CVE runtime, running as nonroot by default.
+#
+# The gateway/hub images stay on the alpine-based Dockerfile because they exec
+# openvpn / wg / nft / ip at runtime and therefore need OS packages.
+
+# Build stage
+FROM golang:1.26.5-alpine AS builder
+
+ARG BINARY=gatekey-server
+
+WORKDIR /app
+
+RUN apk add --no-cache git
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+# CGO_ENABLED=0 -> fully static binary (no libc), so it runs on a distroless
+# base. -tags timetzdata embeds the IANA tz database into the binary, removing
+# the runtime tzdata OS dependency. ca-certificates ship with the base image.
+RUN CGO_ENABLED=0 GOOS=linux go build -tags timetzdata -ldflags="-s -w" \
+    -o /app-binary ./cmd/${BINARY}
+
+# Final image — Chainguard distroless static (nonroot, ca-certificates included)
+FROM cgr.dev/chainguard/static:latest
+
+WORKDIR /app
+
+COPY --from=builder /app-binary /app/gatekey
+# Install scripts served by the control plane
+COPY --from=builder /app/scripts /app/scripts
+
+EXPOSE 8080
+
+ENTRYPOINT ["/app/gatekey"]


### PR DESCRIPTION
## Evaluation: is Chainguard worth it here?

**Yes — for the server.** `gatekey-server` is a pure-Go, CGO-free binary whose only runtime dependencies are a CA bundle and timezone data. That's the textbook case for a distroless base:

| | `alpine:3.23` (before) | `cgr.dev/chainguard/static` (after) |
|---|---|---|
| Shell / package manager / busybox | yes (apk, /bin/sh, busybox) | **none** |
| Default user | root | **nonroot (65532)** |
| CVE surface | full alpine userland | ~0 (just the binary + CA certs) |
| Image size | 81.3 MB | 74.5 MB |

**Deliberately NOT migrating the gateway/hub images.** `gatekey-gateway`, `gatekey-hub`, `gatekey-*wireguard*` exec `openvpn` / `wg` / `nft` / `ip` at runtime, so they need OS packages. A distroless static base has no package manager. Moving those to a **Wolfi** base (`cgr.dev/chainguard/wolfi-base` + `apk`) is viable but needs per-package availability verification (notably `openvpn`, which may require Chainguard's paid catalog) — a separate follow-up, tracked as future work.

## Changes
- **`Dockerfile.server`** — new distroless build. Static binary (`CGO_ENABLED=0`), tzdata embedded via `-tags timetzdata`, `cgr.dev/chainguard/static` runtime.
- **`.github/workflows/ci.yml` / `release.yml`** — add a per-image `dockerfile` field; only the Server image uses `./Dockerfile.server`, everything else falls back to `./Dockerfile` via `${{ matrix.*.dockerfile || './Dockerfile' }}`.

## Verification (local, docker 29.2)
- `docker build -f Dockerfile.server` → succeeds
- `docker run gatekey-server:chainguard --help` → runs on the distroless base ✅
- runtime user = **65532** (nonroot) ✅
- size 74.5 MB vs 81.3 MB alpine

Independent of #144 (touches different files); no conflict.