### PR TITLE
fix(db): make fresh-database migrations apply cleanly

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,10 @@
+# Trivy vulnerability ignore list.
+# Each entry MUST document why the finding is not applicable.
+
+# GO-2026-5932 — golang.org/x/crypto/openpgp is unmaintained/deprecated.
+# GateKey does not import the openpgp subpackage, so it is not compiled into any
+# binary (verified with `govulncheck ./...`, which reports it as NOT called).
+# Trivy matches it at the x/crypto module level regardless. There is no fixed
+# version (the package is deprecated, not patched). Re-evaluate if we ever add
+# an openpgp dependency.
+GO-2026-5932

--- a/internal/db/migrations/000008_system_settings.up.sql
+++ b/internal/db/migrations/000008_system_settings.up.sql
@@ -16,4 +16,4 @@ INSERT INTO system_settings (key, value, description) VALUES
 CREATE TRIGGER update_system_settings_updated_at
     BEFORE UPDATE ON system_settings
     FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at();
+    EXECUTE FUNCTION update_updated_at_column();

--- a/internal/db/migrations/000032_user_access_rules_no_fk.up.sql
+++ b/internal/db/migrations/000032_user_access_rules_no_fk.up.sql
@@ -1,6 +1,11 @@
 -- Remove foreign key constraint on user_access_rules.user_id
 -- This allows assigning access rules to both SSO users (users table) and local users (local_users table)
 
+-- Drop the foreign key to users(id) first: user_id is being widened to
+-- VARCHAR to hold both SSO (users.id UUID) and local (local_users.id) ids, and
+-- an FK to a uuid column cannot survive the type change.
+ALTER TABLE user_access_rules DROP CONSTRAINT IF EXISTS user_access_rules_user_id_fkey;
+
 -- First, drop the primary key constraint (it depends on the column)
 ALTER TABLE user_access_rules DROP CONSTRAINT user_access_rules_pkey;
 

--- a/internal/db/migrations/000043_ipv6_support.up.sql
+++ b/internal/db/migrations/000043_ipv6_support.up.sql
@@ -1,8 +1,20 @@
 -- IPv6 Support Migration
 -- Adds IPv6 columns to networks, gateways, and mesh tables
 
--- Add IPv6 CIDR to networks table
+-- GiST indexes on inet/cidr columns (below) use the inet_ops operator class,
+-- which is provided by the btree_gist contrib extension. Ensure it exists so a
+-- fresh database can apply this migration without relying on it being
+-- pre-provisioned. btree_gist is a trusted extension (creatable by the DB
+-- owner) from PostgreSQL 13 onward.
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+-- Add IPv6 CIDR to networks table.
+-- Migration 000042 already created networks.cidr_v6 as TEXT, so the ADD below is
+-- a no-op on a fresh in-order apply; coerce the column to CIDR so the GiST
+-- inet_ops index further down can be built. The USING cast is safe: cidr_v6
+-- holds a single IPv6 CIDR (or NULL).
 ALTER TABLE networks ADD COLUMN IF NOT EXISTS cidr_v6 CIDR;
+ALTER TABLE networks ALTER COLUMN cidr_v6 TYPE CIDR USING cidr_v6::CIDR;
 COMMENT ON COLUMN networks.cidr_v6 IS 'IPv6 network CIDR (optional, for dual-stack support)';
 
 -- Add IPv6 columns to gateways table

--- a/internal/db/migrations/000045_pending_disconnects.down.sql
+++ b/internal/db/migrations/000045_pending_disconnects.down.sql
@@ -9,6 +9,7 @@ ALTER TABLE gateway_connections
 
 -- Drop indexes
 DROP INDEX IF EXISTS idx_pending_disconnects_cleanup;
+DROP INDEX IF EXISTS idx_pending_disconnects_executed;
 DROP INDEX IF EXISTS idx_pending_disconnects_user;
 DROP INDEX IF EXISTS idx_pending_disconnects_gateway;
 

--- a/internal/db/migrations/000045_pending_disconnects.up.sql
+++ b/internal/db/migrations/000045_pending_disconnects.up.sql
@@ -24,16 +24,25 @@ CREATE TABLE IF NOT EXISTS pending_disconnects (
 );
 
 -- Index for gateway polling (find pending disconnects for a specific gateway)
+-- Partial index over not-yet-executed requests. The expires_at > NOW() filter
+-- was dropped from the predicate (NOW() is not IMMUTABLE and is rejected in
+-- index predicates); callers still filter expires_at at query time.
 CREATE INDEX idx_pending_disconnects_gateway ON pending_disconnects(gateway_id, node_type)
-    WHERE executed_at IS NULL AND expires_at > NOW();
+    WHERE executed_at IS NULL;
 
 -- Index for user lookup (find all pending disconnects for a user)
 CREATE INDEX idx_pending_disconnects_user ON pending_disconnects(user_id)
     WHERE executed_at IS NULL;
 
--- Index for cleanup of expired/executed records
-CREATE INDEX idx_pending_disconnects_cleanup ON pending_disconnects(expires_at)
-    WHERE executed_at IS NOT NULL OR expires_at < NOW();
+-- Index for cleanup of expired/executed records.
+-- A plain btree index on expires_at serves the cleanup scan
+-- (WHERE expires_at < NOW()); the executed_at IS NOT NULL branch is covered by
+-- the partial index below. The previous partial predicate referenced NOW(),
+-- which Postgres rejects ("functions in index predicate must be marked
+-- IMMUTABLE"), so this migration could never apply to a fresh database.
+CREATE INDEX idx_pending_disconnects_cleanup ON pending_disconnects(expires_at);
+CREATE INDEX idx_pending_disconnects_executed ON pending_disconnects(executed_at)
+    WHERE executed_at IS NOT NULL;
 
 -- Add disconnect_requested_at to gateway_connections for tracking
 ALTER TABLE gateway_connections


### PR DESCRIPTION
## Problem
A brand-new database could **not** be migrated from scratch — `gatekey-server` aborted on startup partway through the migration set, so a fresh install never came up. (Discovered while verifying the distroless server image boots against an empty Postgres.)

Because golang-migrate keys off **version numbers, not checksums**, production DBs already past these versions never re-ran them — so only fresh installs hit the bugs, and editing the historical SQL is safe for existing DBs.

## Bugs fixed
| Migration | Bug | Fix |
|---|---|---|
| **000008** | trigger calls `update_updated_at()`, but `000001` defines `update_updated_at_column()` | corrected the function reference |
| **000032** | titled "remove FK" but only drops the **PK**, then widens `user_id` UUID→VARCHAR while the FK to `users(id uuid)` still exists → `incompatible types` | `DROP CONSTRAINT IF EXISTS user_access_rules_user_id_fkey` first |
| **000043** | GiST `inet_ops` index on `networks.cidr_v6`, but `000042` already made that column `TEXT` and `btree_gist` wasn't ensured | `CREATE EXTENSION IF NOT EXISTS btree_gist` + coerce `cidr_v6` to `CIDR` before indexing |
| **000045** | two partial indexes use `NOW()` in the predicate → `functions in index predicate must be marked IMMUTABLE` | drop the time predicate (callers still filter at query time); add an immutable `executed_at` partial index |

## Verification
- `migrate up` applies **all 55 migrations cleanly** (`dirty=false`) on an empty `postgres:16`.
- Distroless server **boots healthy**: `/health`, `/ready`, `/metrics` → `200`, migrations at version 55.
- `go test ./...` — 20 packages pass.
- Down migrations for touched files kept consistent. (The app only runs `Up()` on startup; `Down()` is never invoked in operation.)

## Also
- **`.trivyignore`** documenting `GO-2026-5932` (`x/crypto/openpgp` is unmaintained, **not imported** by GateKey, no fix available) so image scans read a true zero. Chainguard server image scans clean: Wolfi base **0**, Go binary **0**, `govulncheck` **0 called**.

Cut as **v1.11.3** once merged.