### PR TITLE
feat(db): align networks.cidr_v6 to CIDR on existing databases (000056)

### DIFF
--- a/internal/db/migrations/000056_align_cidr_v6_type.down.sql
+++ b/internal/db/migrations/000056_align_cidr_v6_type.down.sql
@@ -1,0 +1,7 @@
+-- Intentional no-op.
+--
+-- 000056 only aligns networks.cidr_v6 to the CIDR type that migration 000043
+-- already establishes on fresh installs. Reverting the type here would diverge
+-- previously-migrated databases from fresh ones, and the idx_networks_cidr_v6
+-- index is owned by 000043's down migration. There is nothing to roll back.
+SELECT 1;

--- a/internal/db/migrations/000056_align_cidr_v6_type.up.sql
+++ b/internal/db/migrations/000056_align_cidr_v6_type.up.sql
@@ -1,0 +1,28 @@
+-- Align networks.cidr_v6 to the CIDR type intended by migration 000043.
+--
+-- Databases that applied an earlier revision of 000043 were left with
+-- networks.cidr_v6 as TEXT and without the idx_networks_cidr_v6 GiST index
+-- (000042 created the column as TEXT and the earlier 000043 did not coerce it).
+-- Fresh installs already have it as CIDR with the index, so every statement
+-- below is written to be idempotent and a no-op there.
+
+-- GiST inet_ops indexing on inet/cidr requires btree_gist.
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+-- Coerce only if the column is not already CIDR. The cast is safe: cidr_v6
+-- holds a single IPv6 CIDR (or NULL).
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'networks'
+          AND column_name = 'cidr_v6'
+          AND udt_name <> 'cidr'
+    ) THEN
+        ALTER TABLE networks ALTER COLUMN cidr_v6 TYPE CIDR USING cidr_v6::CIDR;
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_networks_cidr_v6
+    ON networks USING gist (cidr_v6 inet_ops) WHERE cidr_v6 IS NOT NULL;


### PR DESCRIPTION
## Why
After #146, **fresh** installs get `networks.cidr_v6` as `CIDR` + the `idx_networks_cidr_v6` GiST index (via the corrected `000043`). But databases that already applied the *earlier* revision of `000043` — **including production** — kept `cidr_v6` as `TEXT` with no index. This forward migration aligns those existing databases so all deployments converge on the intended schema.

## What
`000056_align_cidr_v6_type` — fully idempotent, and a **no-op on fresh installs**:
1. `CREATE EXTENSION IF NOT EXISTS btree_gist`
2. Coerce `cidr_v6 → CIDR` **only if** it isn't already CIDR (guarded `DO` block)
3. `CREATE INDEX IF NOT EXISTS idx_networks_cidr_v6 … gist (cidr_v6 inet_ops)`

The cast is safe — `cidr_v6` holds a single IPv6 CIDR or NULL, and production has **0 non-null values**. `down` is an intentional no-op (reverting the type would diverge fresh vs migrated DBs; the index is owned by `000043`'s down).

## Verified
- Fresh `migrate up` → **version 56, dirty=false** (056 no-ops).
- Prod simulation (`cidr_v6` forced to `text`, index dropped) → 056 converts to **`cidr`** and creates the index.
- Re-applying 056 → no-op (idempotent).
- `go build` / `go test ./internal/db/...` pass.

Cut as **v1.11.4** once merged.